### PR TITLE
Remove seccomp syscall argument restrictions for sys containers.

### DIFF
--- a/libsysbox/syscont/spec.go
+++ b/libsysbox/syscont/spec.go
@@ -714,6 +714,18 @@ func cfgSeccomp(seccomp *specs.LinuxSeccomp) error {
 		logrus.Debugf("removed syscalls from seccomp profile: %v", diffSet)
 	}
 
+	if whitelist {
+		// Remove argument restrictions on syscalls (except those for which we
+		// allow such restrictions).
+		for i, syscall := range seccomp.Syscalls {
+			for _, name := range syscall.Names {
+				if !utils.StringSliceContains(syscontSyscallAllowRestrList, name) {
+					seccomp.Syscalls[i].Args = nil
+				}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/libsysbox/syscont/syscalls.go
+++ b/libsysbox/syscont/syscalls.go
@@ -358,6 +358,11 @@ var syscontSyscallWhitelist = []string{
 	"unshare",
 }
 
+// List of syscalls with allowed argument restrictions (via seccomp)
+var syscontSyscallAllowRestrList = []string{
+	"personality",
+}
+
 // List of syscalls trapped & emulated inside a system container
 //
 // NOTE: all of these must also be in the syscontSyscallWhitelist, as otherwise seccomp


### PR DESCRIPTION
The OCI spec allows container managers to use seccomp to restrict syscalls
inside containers. Furthermore, it's possible to restrict syscalls based on
arguments on them.

For example, Docker uses this OCI spec feature to restrict syscalls inside
containers. For the clone() syscall in particular, Docker restricts
the use of clone with CLONE_NEW* flags to clone into new namespaces inside
the container.

The system containers generated by the Sysbox runtime are more permissive in
terms on allowed syscalls, given that they always use the Linux
user-namespace, which ensures root privileges inside the container are
restricted to resources associated with the container.

This change causes Sysbox to remove syscall argument restrictions on
syscalls that Sysbox allows.

Prior to this change, cloning into new namespaces inside a sys container
launched by Docker was not possible. After this change, this is now possible.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>