### PR TITLE
Enable new grpc exchange to collect file-system state from sysbox-mgr [skip ci]

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
@@ -158,6 +159,7 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.22.0 h1:cJv5/xdbk1NnMPR1VP9+HU6gupuG9MLBoH1r6RHZ2MY=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"time"
 
@@ -237,97 +236,6 @@ type Capabilities struct {
 	Permitted []string
 	// Ambient is the ambient set of capabilities that are kept.
 	Ambient []string
-}
-
-//
-// FsEntry type.
-//
-
-type FsEntryKind uint32
-
-const (
-	InvalidFsKind FsEntryKind = iota
-	FileFsKind
-	DirFsKind
-	SoftlinkFsKind
-)
-
-type FsEntry struct {
-	Kind FsEntryKind
-	Path string
-	Mode os.FileMode
-	Dst  string
-}
-
-func NewFsEntry(path, dst string, mode os.FileMode, kind FsEntryKind) *FsEntry {
-
-	entry := &FsEntry{
-		Kind: kind,
-		Path: path,
-		Mode: mode,
-		Dst:  dst,
-	}
-
-	return entry
-}
-
-func (e *FsEntry) Create() error {
-
-	switch e.Kind {
-
-	case FileFsKind:
-		// Check if file exists.
-		var _, err = os.Stat(e.Path)
-
-		// Create file if not exits.
-		if os.IsNotExist(err) {
-			file, err := os.OpenFile(e.Path, os.O_RDWR|os.O_CREATE, e.Mode)
-			if err != nil {
-				return err
-			}
-			defer file.Close()
-		}
-
-	case DirFsKind:
-		if err := os.MkdirAll(e.Path, e.Mode); err != nil {
-			return err
-		}
-
-	case SoftlinkFsKind:
-		// In Linux softlink permissions are irrelevant; i.e. changing a
-		// permission on a symbolic link by chmod() will simply act as if it
-		// was performed against the target of the symbolic link, so we are
-		// obviating it here.
-		if err := os.Symlink(e.Dst, e.Path); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (e *FsEntry) Remove() error {
-	if err := os.RemoveAll(e.Path); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (e *FsEntry) GetPath() string {
-	return e.Path
-}
-
-func (e *FsEntry) GetMode() os.FileMode {
-	return e.Mode
-}
-
-func (e *FsEntry) GetKind() FsEntryKind {
-	return e.Kind
-}
-
-func (e *FsEntry) GetDest() string {
-	return e.Dst
 }
 
 type Hooks struct {

--- a/libcontainer/configs/fsentry.go
+++ b/libcontainer/configs/fsentry.go
@@ -1,0 +1,110 @@
+//
+// Copyright 2020 Nestybox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package configs
+
+import "os"
+
+type FsEntryKind uint32
+
+const (
+	InvalidFsKind FsEntryKind = iota
+	FileFsKind
+	DirFsKind
+	SoftlinkFsKind
+)
+
+//
+// FsEntry type is utilized to hold file-system state (e.g. dir, file, softlinks,
+// etc) to be created in container's rootfs.
+//
+type FsEntry struct {
+	Kind FsEntryKind
+	Path string      // holds the path + name of the fsentry
+	Mode os.FileMode // regular filemode
+	Dst  string      // only relevant in SoftlinkFsKind types
+}
+
+func NewFsEntry(path, dst string, mode os.FileMode, kind FsEntryKind) *FsEntry {
+
+	entry := &FsEntry{
+		Kind: kind,
+		Path: path,
+		Mode: mode,
+		Dst:  dst,
+	}
+
+	return entry
+}
+
+func (e *FsEntry) Add() error {
+
+	switch e.Kind {
+
+	case FileFsKind:
+		// Check if file exists.
+		var _, err = os.Stat(e.Path)
+
+		// Create file if not exits.
+		if os.IsNotExist(err) {
+			file, err := os.OpenFile(e.Path, os.O_RDWR|os.O_CREATE, e.Mode)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+		}
+
+	case DirFsKind:
+		if err := os.MkdirAll(e.Path, e.Mode); err != nil {
+			return err
+		}
+
+	case SoftlinkFsKind:
+		// In Linux softlink permissions are irrelevant; i.e. changing a
+		// permission on a symbolic link by chmod() will simply act as if it
+		// was performed against the target of the symbolic link, so we are
+		// obviating it here.
+		if err := os.Symlink(e.Dst, e.Path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *FsEntry) Remove() error {
+	if err := os.RemoveAll(e.Path); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *FsEntry) GetPath() string {
+	return e.Path
+}
+
+func (e *FsEntry) GetMode() os.FileMode {
+	return e.Mode
+}
+
+func (e *FsEntry) GetKind() FsEntryKind {
+	return e.Kind
+}
+
+func (e *FsEntry) GetDest() string {
+	return e.Dst
+}

--- a/libcontainer/rootfs_init_linux.go
+++ b/libcontainer/rootfs_init_linux.go
@@ -231,9 +231,9 @@ func doDockerDnsSwitch(oldDns, newDns string) error {
 
 // sysbox-runc:
 // Init performs container rootfs initialization actions from within the container's mount
-// namespace only. By virtue of only entering the mount namespace, Init has true
-// root-level access to the host and thus can perform operations that the container's init
-// process is not allowed to.
+// namespace only. By virtue of only entering a specific namespace (e.g. 'mount'), Init has
+// true root-level access to the host and thus can perform operations that the container's
+// init process is not allowed to.
 func (l *linuxRootfsInit) Init() error {
 
 	if len(l.reqs) == 0 {
@@ -244,6 +244,7 @@ func (l *linuxRootfsInit) Init() error {
 	// of the same type.
 
 	switch l.reqs[0].Op {
+
 	case bind:
 
 		// The mount requests assume that the process cwd is the rootfs directory

--- a/libcontainer/rootfs_init_linux.go
+++ b/libcontainer/rootfs_init_linux.go
@@ -230,10 +230,10 @@ func doDockerDnsSwitch(oldDns, newDns string) error {
 }
 
 // sysbox-runc:
-// Init performs container rootfs initialization actions from within the container's mount
-// namespace only. By virtue of only entering a specific namespace (e.g. 'mount'), Init has
-// true root-level access to the host and thus can perform operations that the container's
-// init process is not allowed to.
+// Init performs container's rootfs initialization actions from within specific
+// container namespaces. By virtue of entering to an individual namespace (i.e.
+// 'mount' or 'network' ns), Init has true root-level access to the host and thus
+// can perform operations that the container's init process is not allowed to.
 func (l *linuxRootfsInit) Init() error {
 
 	if len(l.reqs) == 0 {

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -102,6 +102,11 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig) (err error) {
 		return newSystemErrorWithCause(err, "jailing process inside rootfs")
 	}
 
+	//
+	if err := createFsState(config); err != nil {
+		return newSystemErrorWithCause(err, "creating rootfs state")
+	}
+
 	if setupDev {
 		if err := reOpenDevNull(); err != nil {
 			return newSystemErrorWithCause(err, "reopening /dev/null inside container")
@@ -1203,6 +1208,20 @@ func switchDockerDnsIP(config *configs.Config, pipe io.ReadWriter) error {
 
 	if err := ioutil.WriteFile("/proc/sys/net/ipv4/conf/all/route_localnet", []byte("1"), 0644); err != nil {
 		return fmt.Errorf("failed to enble routing of local-host addresses: %s", err)
+	}
+
+	return nil
+}
+
+// Function creates the fsState previously collected from sysbox-mgr. Notice that
+// the path of these fs components is with respect to the container's rootfs, so
+// this instruction should be only called after pivot-root invokation.
+func createFsState(config *configs.Config) error {
+
+	for _, entry := range config.FsState {
+		if err := entry.Create(); err != nil {
+			return newSystemErrorWithCausef(err, "unable to create fsEntry %s", entry.GetPath())
+		}
 	}
 
 	return nil

--- a/libsysbox/sysbox/mgr.go
+++ b/libsysbox/sysbox/mgr.go
@@ -97,6 +97,16 @@ func (mgr *Mgr) ReqShiftfsMark(rootfs string, mounts []configs.ShiftfsMount) err
 	return nil
 }
 
+// ReqFsState sends a request to sysbox-mgr for container's rootfs state.
+func (mgr *Mgr) ReqFsState(rootfs string) ([]configs.FsEntry, error) {
+	state, err := sysboxMgrGrpc.ReqFsState(mgr.Id, rootfs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request fsState from sysbox-mgr: %v", err)
+	}
+
+	return state, nil
+}
+
 func (mgr *Mgr) Pause() error {
 	if err := sysboxMgrGrpc.Pause(mgr.Id); err != nil {
 		return fmt.Errorf("failed to notify pause to sysbox-mgr: %v", err)

--- a/utils_linux.go
+++ b/utils_linux.go
@@ -248,6 +248,20 @@ func createPidFile(path string, process *libcontainer.Process) error {
 	return os.Rename(tmpName, path)
 }
 
+// sysMgrGetFsState inquires sysbox-mgr for special files/dirs to
+// to be added to container's rootfs.
+func sysMgrGetFsState(mgr *sysbox.Mgr, config *configs.Config) error {
+
+	state, err := mgr.ReqFsState(config.Rootfs)
+	if err != nil {
+		return err
+	}
+
+	config.FsState = state
+
+	return nil
+}
+
 func createContainer(context *cli.Context, id string, spec *specs.Spec, shiftUids, switchDockerDns bool, sysMgr *sysbox.Mgr, sysFs *sysbox.Fs) (libcontainer.Container, error) {
 
 	rootlessCg, err := shouldUseRootlessCgroupManager(context)
@@ -268,6 +282,14 @@ func createContainer(context *cli.Context, id string, spec *specs.Spec, shiftUid
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// sysbox-runc: For container's proper operation, collect from sysbox-mgr
+	// fsState to be added to container's rootfs.
+	if sysMgr.Enabled() {
+		if err := sysMgrGetFsState(sysMgr, config); err != nil {
+			return nil, err
+		}
 	}
 
 	// sysbox-runc: setup sys container syscall trapping


### PR DESCRIPTION
Our goal here is to allow sysbox-runc to extract any file-system state that may be required for the proper operation of a sys container. Even though this new logic is generic enough (i.e. to collect any file, dir, softlink), the purpose of this PR is to enable the creation of a softlink in the container's rootfs to allow linux-kernel-headers to be properly found within any sys container; prior to this, kernel-headers could be found in the expected path only in Ubuntu sys-containers.

Example (host running Ubuntu Focal and Fedora sys-container):

<-- The following bind-mounts are created to address linux-headers exposure within the sys container (existing implementation):

```
[root@c3aa727de477 /]# findmnt
...
├─/usr/src/linux-headers-5.4.0-48                            /usr/src/linux-headers-5.4.0-48                    shiftfs  ro,relatime
├─/usr/src/linux-headers-5.4.0-48-generic                    /usr/src/linux-headers-5.4.0-48-generic            shiftfs  ro,relatime
└─/usr/lib/modules/5.4.0-48-generic                          /lib/modules/5.4.0-48-generic                      shiftfs  ro,relatime
```

<-- However, notice that this (/usr/src/linux-headers-<blah>") is not the path expected by Fedora distro (/usr/src/kernels/<blah>). That's why we now create a soft-link between the expected kernel-headers path and the existing one:

[root@c3aa727de477 /]# ls -lrt /usr/src/kernels/5.4.0-48-generic
lrwxrwxrwx 1 root root 39 Nov  5 05:20 /usr/src/kernels/5.4.0-48-generic -> /usr/src/linux-headers-5.4.0-48-generic
[root@c3aa727de477 /]#

Signed-off-by: Rodny Molina <rmolina@nestybox.com>