### PR TITLE
Modify local Makefile to rely on Sysbox's one for kernel-headers operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,21 +41,13 @@ SHIFTFS_MODULE_PRESENT = $(shell lsmod | grep shiftfs)
 LDFLAGS := '-X main.version=${VERSION} -X main.commitId=${COMMIT_ID} \
 			-X "main.builtAt=${BUILT_AT}" -X main.builtBy=${BUILT_BY}'
 
-
-KERNEL_REL := $(shell uname -r)
-HEADERS := linux-headers-$(KERNEL_REL)
-
-# hacky: works on ubuntu but may not work on other distros
-HEADERS_BASE := $(shell find /usr/src/$(HEADERS) -maxdepth 1 -type l -exec readlink {} \; | cut -d"/" -f2 | head -1)
-
 RUN_TEST_CONT := docker run ${DOCKER_RUN_PROXY} -t --privileged --rm \
 		-v $(CURDIR):$(RUNC)                                 \
 		-v $(CURDIR)/../sysbox-ipc:$(NBOX)/sysbox-ipc        \
 		-v $(CURDIR)/../sysbox-libs:$(NBOX)/sysbox-libs      \
 		-v /lib/modules/$(KERNEL_REL):/lib/modules/$(KERNEL_REL):ro \
-		-v /usr/src/$(HEADERS):/usr/src/$(HEADERS):ro               \
-		-v /usr/src/$(HEADERS_BASE):/usr/src/$(HEADERS_BASE):ro     \
 		-v $(GOPATH)/pkg/mod:/go/pkg/mod                            \
+		$(KERNEL_HEADERS_MOUNTS)                                    \
 		$(RUNC_IMAGE)
 
 .DEFAULT: $(RUNC_TARGET)
@@ -140,9 +132,8 @@ shell: runcimage
 	   -v $(CURDIR)/../sysbox-ipc:$(NBOX)/sysbox-ipc     \
 	   -v $(CURDIR)/../lib:$(NBOX)/lib                   \
 	   -v /lib/modules/$(KERNEL_REL):/lib/modules/$(KERNEL_REL):ro \
-	   -v /usr/src/$(HEADERS):/usr/src/$(HEADERS):ro               \
-	   -v /usr/src/$(HEADERS_BASE):/usr/src/$(HEADERS_BASE):ro     \
 	   -v $(GOPATH)/pkg/mod:/go/pkg/mod                            \
+	   $(KERNEL_HEADERS_MOUNTS)                                    \
 	   $(RUNC_IMAGE) bash
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,24 @@ SHIFTFS_MODULE_PRESENT = $(shell lsmod | grep shiftfs)
 LDFLAGS := '-X main.version=${VERSION} -X main.commitId=${COMMIT_ID} \
 			-X "main.builtAt=${BUILT_AT}" -X main.builtBy=${BUILT_BY}'
 
+# Identify kernel-headers path if not previously defined. Notice that this logic is already
+# present in Sysbox's Makefile; we are duplicating it here to keep sysbox-runc as independent
+# as possible. If KERNEL_HEADERS is not already defined, we will assume that the same applies
+# to all related variables declared below.
+ifeq ($(KERNEL_HEADERS),)
+	KERNEL_REL := $(shell uname -r)
+	IMAGE_BASE_DISTRO := $(shell lsb_release -is | tr '[:upper:]' '[:lower:]')
+	ifeq ($(IMAGE_BASE_DISTRO),$(filter $(IMAGE_BASE_DISTRO),centos fedora redhat))
+		KERNEL_HEADERS := kernels/$(KERNEL_REL)
+		KERNEL_HEADERS_MOUNTS := -v /usr/src/$(KERNEL_HEADERS):/usr/src/$(KERNEL_HEADERS):ro
+	else
+		KERNEL_HEADERS := linux-headers-$(KERNEL_REL)
+		KERNEL_HEADERS_BASE := $(shell find /usr/src/$(KERNEL_HEADERS) -maxdepth 1 -type l -exec readlink {} \; | cut -d"/" -f2 | head -1)
+		KERNEL_HEADERS_MOUNTS := -v /usr/src/$(KERNEL_HEADERS):/usr/src/$(KERNEL_HEADERS):ro \
+					 -v /usr/src/$(KERNEL_HEADERS_BASE):/usr/src/$(KERNEL_HEADERS_BASE):ro
+	endif
+endif
+
 RUN_TEST_CONT := docker run ${DOCKER_RUN_PROXY} -t --privileged --rm \
 		-v $(CURDIR):$(RUNC)                                 \
 		-v $(CURDIR)/../sysbox-ipc:$(NBOX)/sysbox-ipc        \


### PR DESCRIPTION
The goal here is to centralize the sysbox's building logic associated to kernel-headers identification in a unique location. The ideal location for this logic is the top-most Makefile (at Sysbox's super-project level).

Signed-off-by: Rodny Molina <rmolina@nestybox.com>