### PR TITLE
Ensure that sysbox-runc connection to Docker API is properly closed.

### DIFF
--- a/utils_linux.go
+++ b/utils_linux.go
@@ -479,8 +479,11 @@ func startContainer(context *cli.Context, spec *specs.Spec, action CtAct, criuOp
 	switchDockerDns := false
 	if sysMgr.Enabled() && sysMgr.Config.AliasDns {
 		docker, err := dockerUtils.DockerConnect()
-		if err == nil && docker.ContainerIsDocker(id) {
-			switchDockerDns = true
+		if err == nil {
+			if docker.ContainerIsDocker(id) {
+				switchDockerDns = true
+			}
+			docker.Disconnect()
 		}
 	}
 


### PR DESCRIPTION
This prevents sysbox-runc from leaking file-descriptors.

Signed-off-by: ctalledo <ctalledo@nestybox.com>