### PR TITLE
Do not mount tmpfs on a sys container's /tmp for sys containers with systemd.

### DIFF
--- a/libsysbox/syscont/spec.go
+++ b/libsysbox/syscont/spec.go
@@ -209,12 +209,6 @@ var sysboxSystemdMounts = []specs.Mount{
 		Type:        "tmpfs",
 		Options:     []string{"rw", "rprivate", "noexec", "nosuid", "nodev", "size=4m"},
 	},
-	specs.Mount{
-		Destination: "/tmp",
-		Source:      "tmpfs",
-		Type:        "tmpfs",
-		Options:     []string{"rw", "rprivate", "noexec", "nosuid", "nodev", "size=64m"},
-	},
 }
 
 // sysbox's systemd env-vars requirements

--- a/libsysbox/syscont/spec_test.go
+++ b/libsysbox/syscont/spec_test.go
@@ -306,12 +306,6 @@ func TestCfgSystemd(t *testing.T) {
 			Type:        "bind",
 			Options:     []string{"ro", "rprivate"},
 		},
-		specs.Mount{
-			Source:      "/another/path",
-			Destination: "/tmp",
-			Type:        "bind",
-			Options:     []string{"rw", "rprivate", "noexec"},
-		},
 	}
 
 	// This call should remove the conflicting info above
@@ -335,12 +329,6 @@ func TestCfgSystemd(t *testing.T) {
 			Destination: "/run/lock",
 			Type:        "tmpfs",
 			Options:     []string{"rw", "rprivate", "noexec", "nosuid", "nodev", "size=4m"},
-		},
-		specs.Mount{
-			Source:      "tmpfs",
-			Destination: "/tmp",
-			Type:        "tmpfs",
-			Options:     []string{"rw", "rprivate", "noexec", "nosuid", "nodev", "size=64m"},
 		},
 	}
 
@@ -371,12 +359,6 @@ func TestCfgSystemdOverride(t *testing.T) {
 			Destination: "/run/lock",
 			Type:        "tmpfs",
 			Options:     []string{"rw", "nosuid", "noexec", "size=8m"},
-		},
-		specs.Mount{
-			Source:      "/yetanotherpath",
-			Destination: "/tmp",
-			Type:        "tmpfs",
-			Options:     []string{"rw", "nosuid", "noexec", "size=128m"},
 		},
 	}
 


### PR DESCRIPTION
Prior to this change, sysbox-runc would automatically mount tmpfs on the "/tmp" directory of sys containers that use systemd.

This is not necessary, as there is no requirement by systemd that "/tmp" be a tmpfs mount.

This change removes this mount.

Signed-off-by: ctalledo <ctalledo@nestybox.com>