### PR TITLE
Sysbox-runc changes required along the mount-hardening modifications made in sysbox-fs component

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -188,6 +189,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 h1:5Beo0mZN8dRzgrMMkDp0jc8YXQKx9DiJ2k1dkvGsn5A=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -231,4 +233,5 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc h1:/hemPrYIhOhy8zYrNj+069zDB68us2sMGsfkFJO0iZs=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -305,6 +305,19 @@ func syncParentSeccompFd(fd int32, pipe *os.File) error {
 	return nil
 }
 
+// sysbox-runc:
+// syncParentRootfsReady sends a notification to parent to indicate that the
+// container's rootfs is fully initialized, and that it's time for the parent
+// to register the container with sysbox-fs component.
+func syncParentRootfsReady(pipe *os.File) error {
+	if err := writeSync(pipe, rootfsReady); err != nil {
+		return err
+	}
+
+	// Wait for parent to acknowledge rootfsReady msg.
+	return readSync(pipe, rootfsReadyAck)
+}
+
 // setupUser changes the groups, gid, and uid for the user inside the container
 func setupUser(config *initConfig) error {
 	// Set up defaults.

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -513,8 +513,8 @@ func (p *initProcess) start() (retErr error) {
 			sentRun = true
 
 		case rootfsReady:
-			// Register container into sysbox-fs.
-			if err = p.register(childPid); err != nil {
+			// Register container with sysbox-fs.
+			if err = p.registerWithSysboxfs(childPid); err != nil {
 				return err
 			}
 			// Sync with child.
@@ -610,7 +610,7 @@ func (p *initProcess) start() (retErr error) {
 // sysbox-runc: register the container with sysbox-fs. This must be done after
 // childPid is obtained and all container mounts are present, but before prestart
 // hooks so that sysbox-fs is ready to respond by the time the hooks run.
-func (p *initProcess) register(childPid int) error {
+func (p *initProcess) registerWithSysboxfs(childPid int) error {
 
 	sysFs := p.container.sysFs
 	if !sysFs.Enabled() {

--- a/libcontainer/sync.go
+++ b/libcontainer/sync.go
@@ -11,7 +11,7 @@ import (
 
 type syncType string
 
-// Constants that are used for synchronisation between the parent and child
+// Constants that are used for synchronization between the parent and child
 // during container setup. They come in pairs (with procError being a generic
 // response which is followed by a &genericError).
 //
@@ -22,16 +22,20 @@ type syncType string
 // [send(info)] --> [recv(info)]
 //              <-- opDone
 //
+// procHooks    --> [run hooks]
+//              <-- procResume
+//
+// rootfsReady  --> [complete container registration]
+//              <-- rootfsReadyAck
+//
+// procReady    --> [final setup]
+//              <-- procRun
+//
 // procFd       -->
 //              <-- sendFd
 // [send(fd)]   --> [recv(fd)]
 //              <-- procFdDone
 //
-// procHooks    --> [run hooks]
-//              <-- procResume
-//
-// procReady    --> [final setup]
-//              <-- procRun
 
 const (
 	procError  syncType = "procError"
@@ -47,6 +51,9 @@ const (
 	procFd     syncType = "procFd"
 	sendFd     syncType = "sendFd"
 	procFdDone syncType = "procFdDone"
+
+	rootfsReady    syncType = "rootfsReady"
+	rootfsReadyAck syncType = "rootfsReadyAck"
 )
 
 type syncT struct {


### PR DESCRIPTION
As part of these changes we are deferring the container registration process till the container's rootfs preparation is completed. By doing this, we are ensuring that sysbox-runc has concluded mounting all the required resources, by the time it attempts to register a container with sysbox-fs.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>