### PR TITLE
Fix for sysbox issue #202

### DIFF
--- a/libcontainer/nsenter/nsenter.go
+++ b/libcontainer/nsenter/nsenter.go
@@ -10,3 +10,4 @@ void __attribute__((constructor)) init(void) {
 }
 */
 import "C"
+


### PR DESCRIPTION
A recent change in Docker modifies the way in which Docker sets ownership of the
"/var/lib/docker/<remapping>" dir (and its subdirs) in userns-remap mode.

This was causing the container's init process spawned by sysbox-runc to loose
permission when preparing the container rootfs mounts. This change fixes this by
making sysbox-runc try the rootfs preparations before userns uid-mapping
occurs and in case this does not work, trying them after the userns uid-mappings.

With this change, the latest versions of Docker can work with sysbox-runc.
Earlier versions also work without problem.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>