### PR TITLE
Adding new syscalls to seccomp profile to resolve compatibility issues

### DIFF
--- a/libsysbox/syscont/syscalls.go
+++ b/libsysbox/syscont/syscalls.go
@@ -191,6 +191,7 @@ var syscontSyscallWhitelist = []string{
 	"_newselect",
 	"open",
 	"openat",
+	"openat2",
 	"pause",
 	"pipe",
 	"pipe2",

--- a/libsysbox/syscont/syscalls.go
+++ b/libsysbox/syscont/syscalls.go
@@ -65,6 +65,7 @@ var syscontSyscallWhitelist = []string{
 	"exit",
 	"exit_group",
 	"faccessat",
+	"faccessat2",
 	"fadvise64",
 	"fadvise64_64",
 	"fallocate",


### PR DESCRIPTION
This PR is a proposed solution for the issue https://github.com/nestybox/sysbox/issues/273

I mainly applies the same fixes as in PR https://github.com/moby/moby/pull/41353

Compatible version of `libseccomp` might be an issue from now on,
unless you embed one into the product itself.

I have no clue how to build sysbox project so I haven't tested these changes.

I missed sign-off on commits but I made them all on GitHub website itself, so that shall be enough of a verification.