### PR TITLE
Fix symlink existence check in FsEntry.add

### DIFF
--- a/libcontainer/configs/fsentry.go
+++ b/libcontainer/configs/fsentry.go
@@ -74,7 +74,7 @@ func (e *FsEntry) Add() error {
 
 	case SoftlinkFsKind:
 		// Check if softlink exists.
-		var _, err = os.Stat(e.Path)
+		var _, err = os.Lstat(e.Path)
 
 		// Create softlink if not present.
 		if os.IsNotExist(err) {


### PR DESCRIPTION
The check in `FsEntry.add` for the `SoftlinkFsKind` case is supposed to check if the symlink exists, but it used `os.Stat()` which will follow the symlink if it exists and thus check the existence of the target and not the symlink itself.

Use `os.Lstat()` instead which will not follow the symlink.

The check caused an error when restarting (docker stop + docker start) some containers (e.g. Alpine-based) on my Arch Linux system, since the creation of the symlink to the Linux kernel headers failed. It doesn't appear to reproduce on Ubuntu nor Fedora, and I'm not 100% sure of the exact circumstances. Arch may be special because the module path in Arch is in /lib/modules itself.

All tests OK (`make test-sysbox-shiftuid`).
