### PR TITLE
Changes to improve security of shiftfs mounts.

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -475,7 +475,7 @@ func doBindMounts(config *configs.Config, pipe io.ReadWriter) error {
 		for _, mr := range mntReqs {
 
 			// Mount destinations in mntReqs are relative to the rootfs
-			// (see prepareBindDest()); thus we need to prepent "/" for a
+			// (see prepareBindDest()); thus we need to prepend "/" for a
 			// proper comparison.
 			if strings.HasPrefix(m.Destination, filepath.Join("/", mr.Mount.Destination)) {
 				mntDependsOnPrior = true
@@ -1117,48 +1117,6 @@ func validateCwd(rootfs string) error {
 	if cwd != rootfs {
 		return newSystemErrorWithCausef(err, "cwd %s is not container's rootfs %s", cwd, rootfs)
 	}
-	return nil
-}
-
-// sysbox-runc: allowShiftfsBindSource checks if Sysbox is capable of mounting shiftfs
-// over the source dir of a bind mount.
-func allowShiftfsBindSource(config *configs.Config, source string) error {
-
-	// We do not allow bind mounts whose source is directly above the container's rootfs
-	// (e.g., if the rootfs is at /a/b/c/d, we don't allow bind sources at /, /a, /a/b, or
-	// /a/b/c; but we do allow them at /a/x, /a/b/x, or /a/b/c/x). The reason we disallow
-	// such bind mounts is that when using uid-shifting we need to mount shiftfs on the
-	// rootfs as well as the bind sources. If we where to allow bind sources directly above
-	// rootfs, we would end with shiftfs-on-shiftfs which is not supported.
-	if strings.Contains(config.Rootfs, source) {
-		return fmt.Errorf("bind mount with source at %s is above the container's rootfs at %s;"+
-			" this is not supported when using uid-shifting", source, config.Rootfs)
-	}
-
-	return nil
-}
-
-// The following are host directories where we never mount shiftfs, as they contain
-// critical excutables for the host and mounting shiftfs on them will implicitly make
-// them non-executable in the host's mount namespace, rendering the host unusable.
-var shiftfsBlackList = []string{
-	"/", "/bin", "/sbin", "/usr/bin", "/usr/sbin", "/usr/local/bin", "/usr/local/sbin", "/dev", "/run", "/var/run",
-}
-
-// sysbox-runc: skipShiftfsBindSource indicates if shiftfs mounts should be skipped on the
-// given directory.
-func skipShiftfsBindSource(source string) error {
-
-	// Since shiftfs marks are set on the host's mount namespace and are implicitly
-	// "noexec" mounts, we skip them over host directories with critical executables
-	// needed for the system (as otherwise the shiftfs mount will render the host
-	// unusable).
-	for _, m := range shiftfsBlackList {
-		if source == m {
-			return fmt.Errorf("skipping shiftfs mount on bind source at %s as it will render the mountpoint non-executable on the host", source)
-		}
-	}
-
 	return nil
 }
 

--- a/libsysbox/shiftfs/shiftfs.go
+++ b/libsysbox/shiftfs/shiftfs.go
@@ -24,22 +24,29 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Mark performs a shiftf mark on the given path
-func Mark(path string) error {
-	if err := unix.Mount(path, path, "shiftfs", 0, "mark"); err != nil {
-		return fmt.Errorf("failed to mark shiftfs on %s: %v", path, err)
+// Mark performs a shiftfs mark-mount for path on the given markPath
+// (e.g., Mark("/a/b", "/c/d") causes "b" to be mounted on "d" and
+// "d" to have a shiftfs mark).
+func Mark(path, markPath string) error {
+	if err := unix.Mount(path, markPath, "shiftfs", 0, "mark"); err != nil {
+		return fmt.Errorf("failed to mark shiftfs on %s at %s: %v", path, markPath, err)
 	}
 	return nil
 }
 
-// Mount performs a shiftfs mount on the give path; the path must have a shiftfs mark on it already
-func Mount(path string) error {
-	if err := unix.Mount(path, path, "shiftfs", 0, ""); err != nil {
-		return fmt.Errorf("failed to mount shiftfs on %s: %v", path, err)
+// Mount performs a shiftfs mount on the given path; the path must have a
+// shiftfs mark on it already (e.g., Mount("/c/d", "/x/y") requires that
+// "d" have a shiftfs mark on it and causes "d" to be mounted on "y" and
+// "y" to have a shiftfs mount).
+func Mount(path, mntPath string) error {
+	if err := unix.Mount(path, mntPath, "shiftfs", 0, ""); err != nil {
+		return fmt.Errorf("failed to mount shiftfs on %s at %s: %v", path, mntPath, err)
 	}
 	return nil
 }
 
+// Unmount perform a shiftfs unmount on the given path. The path must have
+// a shiftfs mark or mount on it.
 func Unmount(path string) error {
 	if err := unix.Unmount(path, unix.MNT_DETACH); err != nil {
 		return fmt.Errorf("failed to unmount %s: %v", path, err)
@@ -47,6 +54,8 @@ func Unmount(path string) error {
 	return nil
 }
 
+// Returns a boolean indicating if the given path has a shiftfs mount
+// on it (mark or actual mount).
 func Mounted(path string) (bool, error) {
 	realPath, err := filepath.EvalSymlinks(path)
 	if err != nil {

--- a/libsysbox/sysbox/mgr.go
+++ b/libsysbox/sysbox/mgr.go
@@ -48,7 +48,7 @@ func (mgr *Mgr) Enabled() bool {
 	return mgr.Active
 }
 
-// Register registers the container with sysbox-mgr. If successful, returns
+// Registers the container with sysbox-mgr. If successful, returns
 // configuration tokens for sysbox-runc.
 func (mgr *Mgr) Register(spec *specs.Spec) error {
 	var userns string
@@ -97,7 +97,7 @@ func (mgr *Mgr) Update(userns, netns string, uidMappings, gidMappings []specs.Li
 	return nil
 }
 
-// Unregister unregisters the container with sysbox-mgr.
+// Unregisters the container with sysbox-mgr.
 func (mgr *Mgr) Unregister() error {
 	if err := sysboxMgrGrpc.Unregister(mgr.Id); err != nil {
 		return fmt.Errorf("failed to unregister with sysbox-mgr: %v", err)
@@ -132,11 +132,12 @@ func (mgr *Mgr) ReqMounts(rootfs string, uid, gid uint32, shiftUids bool, reqLis
 }
 
 // ReqShiftfsMark sends a request to sysbox-mgr to mark shiftfs on the given dirs; all paths must be absolute.
-func (mgr *Mgr) ReqShiftfsMark(mounts []configs.ShiftfsMount) error {
-	if err := sysboxMgrGrpc.ReqShiftfsMark(mgr.Id, mounts); err != nil {
-		return fmt.Errorf("failed to request shiftfs marking to sysbox-mgr: %v", err)
+func (mgr *Mgr) ReqShiftfsMark(mounts []configs.ShiftfsMount) ([]configs.ShiftfsMount, error) {
+	resp, err := sysboxMgrGrpc.ReqShiftfsMark(mgr.Id, mounts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request shiftfs marking to sysbox-mgr: %v", err)
 	}
-	return nil
+	return resp, nil
 }
 
 // ReqFsState sends a request to sysbox-mgr for container's rootfs state.


### PR DESCRIPTION
These changes are needed in sysbox-runc due to a change in the way sysbox-mgr
will setup shiftfs mounts on host directories/files that are bind-mounted into
containers. Refer to the corresponding change in sysbox-mgr for details.

In sysbox-runc, the changes are mainly to receive from sysbox-mgr the list of
dirs under /var/lib/sysbox/shiftfs/ where the shiftfs mounts have been setup.
sysbox-runc will then bind-mount these into the appropriate directories
in the container.

A benefit of this change is that a couple of shiftfs-mount restrictions that
sysbox-runc was previously imposing no longer apply (e.g., the list of host dirs
in the shiftfs blacklist is no longer required). This gives more flexibility to
users in the host dirs that they can bind-mount into Sysbox containers.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>