### PR TITLE
Don't mount shiftfs on /dev.

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2530,6 +2530,10 @@ func (c *linuxContainer) setupShiftfsMarks() error {
 					dir = m.Source
 				}
 
+				if skipShiftfsBindSource(dir) {
+					continue
+				}
+
 				duplicate := false
 				for _, sm := range shiftfsMounts {
 					if sm.Source == dir {
@@ -2634,4 +2638,18 @@ func (c *linuxContainer) teardownShiftfsMarkLocal() error {
 	}
 
 	return nil
+}
+
+// The following are host directories where we never mount shiftfs as it causes functional problems.
+var shiftfsBlackList = []string{"/dev"}
+
+// sysbox-runc: skipShiftfsBindSource indicates if shiftfs mounts should be skipped on the
+// given directory.
+func skipShiftfsBindSource(source string) bool {
+	for _, m := range shiftfsBlackList {
+		if source == m {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
A prior change to improve shiftfs mount security (commit 98fcbfe3)
had the side-effect that host devices bind mounted into the
system container's /dev dir (e.g., /dev/null, /dev/kmsg, etc.)
where now under shiftfs.

While this causes the permissions of such devices to show up
properly inside the container, it is unfortunately causing
kubernetes-in-docker to fail with Sysbox (i.e., the k8s
kubelet reports it can't open /dev/kmsg). I suspect some
sort of incompatibility between the file open flags and shiftfs,
but this requires further investigation.

To avoid a regression, this change ensures sysbox won't mount
shiftfs on host devices bind mounted into the sys conatiner's
/dev dir. This is how things used to be prior to the
shiftfs mount security change in commit 98fcbfe3.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>