### PR TITLE
Set cgroup v1 mem limits in the sys container cgroup root.

### DIFF
--- a/libcontainer/cgroups/fs/blkio.go
+++ b/libcontainer/cgroups/fs/blkio.go
@@ -69,6 +69,19 @@ func (s *BlkioGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
+func (s *BlkioGroup) Clone(source, dest string) error {
+
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
+	}
+
+	return nil
+}
+
 /*
 examples:
 

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -114,3 +114,16 @@ func (s *CpuGroup) GetStats(path string, stats *cgroups.Stats) error {
 	}
 	return nil
 }
+
+func (s *CpuGroup) Clone(source, dest string) error {
+
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
+	}
+
+	return nil
+}

--- a/libcontainer/cgroups/fs/cpuacct.go
+++ b/libcontainer/cgroups/fs/cpuacct.go
@@ -80,6 +80,19 @@ func (s *CpuacctGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }
 
+func (s *CpuacctGroup) Clone(source, dest string) error {
+
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
+	}
+
+	return nil
+}
+
 // Returns user and kernel usage breakdown in nanoseconds.
 func getCpuUsageBreakdown(path string) (uint64, uint64, error) {
 	var userModeUsage, kernelModeUsage uint64

--- a/libcontainer/cgroups/fs/cpuset.go
+++ b/libcontainer/cgroups/fs/cpuset.go
@@ -42,6 +42,20 @@ func (s *CpusetGroup) Set(path string, cgroup *configs.Cgroup) error {
 	return nil
 }
 
+func (s *CpusetGroup) Clone(source, dest string) error {
+
+	// For the cpuset cgroup, cloning is done by simply setting cgroup.clone_children on the source
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
+	}
+
+	return nil
+}
+
 func getCpusetStat(path string, filename string) ([]uint16, error) {
 	var extracted []uint16
 	fileContent, err := fscommon.GetCgroupParamString(path, filename)

--- a/libcontainer/cgroups/fs/devices.go
+++ b/libcontainer/cgroups/fs/devices.go
@@ -5,6 +5,8 @@ package fs
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"os"
 	"reflect"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -107,5 +109,18 @@ func (s *DevicesGroup) Set(path string, cgroup *configs.Cgroup) error {
 }
 
 func (s *DevicesGroup) GetStats(path string, stats *cgroups.Stats) error {
+	return nil
+}
+
+func (s *DevicesGroup) Clone(source, dest string) error {
+
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
+	}
+
 	return nil
 }

--- a/libcontainer/cgroups/fs/freezer.go
+++ b/libcontainer/cgroups/fs/freezer.go
@@ -87,3 +87,16 @@ func (s *FreezerGroup) GetState(path string) (configs.FreezerState, error) {
 		}
 	}
 }
+
+func (s *FreezerGroup) Clone(source, dest string) error {
+
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
+	}
+
+	return nil
+}

--- a/libcontainer/cgroups/fs/hugetlb.go
+++ b/libcontainer/cgroups/fs/hugetlb.go
@@ -4,6 +4,7 @@ package fs
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -60,6 +61,19 @@ func (s *HugetlbGroup) GetStats(path string, stats *cgroups.Stats) error {
 		hugetlbStats.Failcnt = value
 
 		stats.HugetlbStats[pageSize] = hugetlbStats
+	}
+
+	return nil
+}
+
+func (s *HugetlbGroup) Clone(source, dest string) error {
+
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
 	}
 
 	return nil

--- a/libcontainer/cgroups/fs/name.go
+++ b/libcontainer/cgroups/fs/name.go
@@ -3,7 +3,11 @@
 package fs
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
@@ -29,5 +33,18 @@ func (s *NameGroup) Set(path string, cgroup *configs.Cgroup) error {
 }
 
 func (s *NameGroup) GetStats(path string, stats *cgroups.Stats) error {
+	return nil
+}
+
+func (s *NameGroup) Clone(source, dest string) error {
+
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
+	}
+
 	return nil
 }

--- a/libcontainer/cgroups/fs/net_cls.go
+++ b/libcontainer/cgroups/fs/net_cls.go
@@ -3,6 +3,8 @@
 package fs
 
 import (
+	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -32,5 +34,18 @@ func (s *NetClsGroup) Set(path string, cgroup *configs.Cgroup) error {
 }
 
 func (s *NetClsGroup) GetStats(path string, stats *cgroups.Stats) error {
+	return nil
+}
+
+func (s *NetClsGroup) Clone(source, dest string) error {
+
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
+	}
+
 	return nil
 }

--- a/libcontainer/cgroups/fs/net_prio.go
+++ b/libcontainer/cgroups/fs/net_prio.go
@@ -3,6 +3,9 @@
 package fs
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -30,5 +33,18 @@ func (s *NetPrioGroup) Set(path string, cgroup *configs.Cgroup) error {
 }
 
 func (s *NetPrioGroup) GetStats(path string, stats *cgroups.Stats) error {
+	return nil
+}
+
+func (s *NetPrioGroup) Clone(source, dest string) error {
+
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
+	}
+
 	return nil
 }

--- a/libcontainer/cgroups/fs/perf_event.go
+++ b/libcontainer/cgroups/fs/perf_event.go
@@ -3,7 +3,11 @@
 package fs
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/cgroups/fscommon"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
@@ -23,5 +27,18 @@ func (s *PerfEventGroup) Set(path string, cgroup *configs.Cgroup) error {
 }
 
 func (s *PerfEventGroup) GetStats(path string, stats *cgroups.Stats) error {
+	return nil
+}
+
+func (s *PerfEventGroup) Clone(source, dest string) error {
+
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
+	}
+
 	return nil
 }

--- a/libcontainer/cgroups/fs/pids.go
+++ b/libcontainer/cgroups/fs/pids.go
@@ -4,6 +4,7 @@ package fs
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -65,5 +66,18 @@ func (s *PidsGroup) GetStats(path string, stats *cgroups.Stats) error {
 
 	stats.PidsStats.Current = current
 	stats.PidsStats.Limit = max
+	return nil
+}
+
+func (s *PidsGroup) Clone(source, dest string) error {
+
+	if err := fscommon.WriteFile(source, "cgroup.clone_children", "1"); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("Failed to create cgroup %s", dest)
+	}
+
 	return nil
 }

--- a/libcontainer/cgroups/fscommon/fscommon.go
+++ b/libcontainer/cgroups/fscommon/fscommon.go
@@ -4,6 +4,8 @@ package fscommon
 
 import (
 	"bytes"
+	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -37,6 +39,40 @@ func ReadFile(dir, file string) (string, error) {
 
 	_, err = buf.ReadFrom(fd)
 	return buf.String(), err
+}
+
+func CopyFile(source, dest string) error {
+	var (
+		srcF *os.File
+		dstF *os.File
+		data []byte
+		err  error
+	)
+
+	srcF, err = os.Open(source)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %s", source, err)
+	}
+	defer srcF.Close()
+
+	dstF, err = os.Open(dest)
+	if err != nil {
+		dstF.Close()
+		return fmt.Errorf("failed to open %s: %s", dest, err)
+	}
+	defer dstF.Close()
+
+	data, err = ioutil.ReadFile(source)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %s", source, err)
+	}
+
+	err = ioutil.WriteFile(dest, data, 0)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %s", dest, err)
+	}
+
+	return nil
 }
 
 func retryingWriteFile(fd *os.File, data string) error {


### PR DESCRIPTION
When a container starts, the container manager / orchestrator passes the cgroup
path associated with the container to Sysbox.  These cgroup path points to the
cgroup dirs that contain the resource limits for the container. Sysbox then
creates a child cgroup to serve as the "cgroup delegation" boundary for the
container (i.e., to allow container processes to create further cgroups
without affecting the cgroups of the container itself).

When creating the child cgroup, Sysbox was not copying the limits of the parent
cgroup to the child. Such a copy is really not necessary because the parent
cgroup settings constrain the child cgroup.

However, per Sysbox issue #303, this was inadvertendly causing the "docker
stats" command to report the incorrect mem limits for the container (i.e.,
docker stats is picking the mem limit from the child cgroup, not from the parent
cgroup).

This commit fixes this by copying the memory limits from the parent
cgroup to the child cgroup.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>