### PR TITLE
Weave-Net CNI support

### DIFF
--- a/libsysbox/syscont/spec.go
+++ b/libsysbox/syscont/spec.go
@@ -185,7 +185,12 @@ var sysboxFsMounts = []specs.Mount{
 	//
 	// sysfs mounts
 	//
-
+	specs.Mount{
+		Destination: "/sys/devices/virtual/dmi/id/product_uuid",
+		Source:      filepath.Join(SysboxFsDir, "/sys/devices/virtual/dmi/id/product_uuid"),
+		Type:        "bind",
+		Options:     []string{"rbind", "rprivate"},
+	},
 	specs.Mount{
 		Destination: "/sys/module/nf_conntrack/parameters/hashsize",
 		Source:      filepath.Join(SysboxFsDir, "sys/module/nf_conntrack/parameters/hashsize"),


### PR DESCRIPTION
Expose 'product_uuid' node required for WeaveNet and Calico consumption.

[ already internally reviewed ]

Signed-off-by: Rodny Molina <rmolina@nestybox.com>