### PR TITLE
Add support for cgroups v2 in Sysbox ...

### DIFF
--- a/libcontainer/cgroups/cgroups.go
+++ b/libcontainer/cgroups/cgroups.go
@@ -14,6 +14,15 @@ import (
 
 var SyscontCgroupRoot string = "syscont-cgroup-root"
 
+type CgroupType int
+
+const (
+	Cgroup_v1_fs CgroupType = iota
+	Cgroup_v1_systemd
+	Cgroup_v2_fs
+	Cgroup_v2_systemd
+)
+
 type Manager interface {
 	// Applies cgroup configuration to the process with the specified pid
 	Apply(pid int) error
@@ -72,4 +81,7 @@ type Manager interface {
 
 	// sysbox-runc: same as GetPaths(), but returns child cgroup paths
 	GetChildCgroupPaths() map[string]string
+
+	// sysbox-runc: get the type of the cgroup manager
+	GetType() CgroupType
 }

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -548,3 +548,7 @@ func (m *manager) GetFreezerState() (configs.FreezerState, error) {
 func (m *manager) Exists() bool {
 	return cgroups.PathExists(m.Path("devices"))
 }
+
+func (m *manager) GetType() cgroups.CgroupType {
+	return cgroups.Cgroup_v1_fs
+}

--- a/libcontainer/cgroups/fs/fs.go
+++ b/libcontainer/cgroups/fs/fs.go
@@ -222,7 +222,7 @@ func isIgnorableError(rootless bool, err error) bool {
 	return false
 }
 
-func (m *manager) CreateChildCgroup(container *configs.Config) error {
+func (m *manager) CreateChildCgroup(config *configs.Config) error {
 	paths := m.GetPaths()
 	for _, sys := range subsystems {
 		cgroupPath := paths[sys.Name()]
@@ -235,11 +235,11 @@ func (m *manager) CreateChildCgroup(container *configs.Config) error {
 			}
 
 			// Change child cgroup ownership to match the root user in the system container
-			rootuid, err := container.HostRootUID()
+			rootuid, err := config.HostRootUID()
 			if err != nil {
 				return err
 			}
-			rootgid, err := container.HostRootGID()
+			rootgid, err := config.HostRootGID()
 			if err != nil {
 				return err
 			}

--- a/libcontainer/cgroups/fs2/create.go
+++ b/libcontainer/cgroups/fs2/create.go
@@ -107,6 +107,7 @@ func CreateCgroupPath(path string, c *configs.Cgroup) (Err error) {
 			}
 			cgType, _ := fscommon.ReadFile(current, cgTypeFile)
 			cgType = strings.TrimSpace(cgType)
+
 			switch cgType {
 			// If the cgroup is in an invalid mode (usually this means there's an internal
 			// process in the cgroup tree, because we created a cgroup under an

--- a/libcontainer/cgroups/fs2/fs2.go
+++ b/libcontainer/cgroups/fs2/fs2.go
@@ -302,12 +302,12 @@ func (m *manager) CreateChildCgroup(config *configs.Config) error {
 	}
 
 	// Create a leaf cgroup to be used for the sys container's init process (and
-	// for all it's child processes). It's purpose is to prevent processes from
-	// living the sys container's cgroup root, because once inner sub-cgroups are
-	// created, the kernel considers the sys container's cgroup root an
+	// for all its child processes). Its purpose is to prevent processes from
+	// living in the sys container's cgroup root, because once inner sub-cgroups
+	// are created, the kernel considers the sys container's cgroup root an
 	// intermediate node in the global cgroup hierarchy. This in turn forces all
 	// sub-groups inside the sys container to be of "domain-invalid" type (and
-	// thus preventing domain cgroup controllers such as the memory controller
+	// thus prevents domain cgroup controllers such as the memory controller
 	// from being applied inside the sys container).
 	//
 	// We choose the name "init.scope" for the leaf cgroup because it works well

--- a/libcontainer/cgroups/systemd/v1.go
+++ b/libcontainer/cgroups/systemd/v1.go
@@ -520,3 +520,7 @@ func (m *legacyManager) GetChildCgroupPaths() map[string]string {
 	childMgr := fs.NewManager(m.cgroups, m.paths, false)
 	return childMgr.GetChildCgroupPaths()
 }
+
+func (m *legacyManager) GetType() cgroups.CgroupType {
+	return cgroups.Cgroup_v1_systemd
+}

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -553,12 +553,12 @@ func (m *unifiedManager) CreateChildCgroup(config *configs.Config) error {
 	}
 
 	// Create a leaf cgroup to be used for the sys container's init process (and
-	// for all it's child processes). It's purpose is to prevent processes from
-	// living the sys container's cgroup root, because once inner sub-cgroups are
+	// for all its child processes). Its purpose is to prevent processes from
+	// living in the sys container's cgroup root, because once inner sub-cgroups are
 	// created, the kernel considers the sys container's cgroup root an
 	// intermediate node in the global cgroup hierarchy. This in turn forces all
 	// sub-groups inside the sys container to be of "domain-invalid" type (and
-	// thus preventing domain cgroup controllers such as the memory controller
+	// thus prevents domain cgroup controllers such as the memory controller
 	// from being applied inside the sys container).
 	//
 	// We choose the name "init.scope" for the leaf cgroup because it works well

--- a/libcontainer/cgroups/systemd/v2.go
+++ b/libcontainer/cgroups/systemd/v2.go
@@ -516,3 +516,7 @@ func (m *unifiedManager) GetChildCgroupPaths() map[string]string {
 	// sysbox-runc: implement this function
 	return nil
 }
+
+func (m *unifiedManager) GetType() cgroups.CgroupType {
+	return cgroups.Cgroup_v2_systemd
+}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2651,5 +2651,11 @@ func skipShiftfsBindSource(source string) bool {
 			return true
 		}
 	}
+
+	// Don't mount shiftfs on cgroup v2 bind-source either
+	if strings.HasPrefix(source, "/sys/fs/cgroup") {
+		return true
+	}
+
 	return false
 }


### PR DESCRIPTION
These commits add cgroups v2 support in Sysbox (i.e., for hosts whose kernel is configured with cgroups v2).