### PR TITLE
Fix UID/GID mismatch issue in rootfs' /dev resource

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,9 @@ github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXy
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
+github.com/nestybox/sysbox-libs v0.0.0-20210524172525-ee7d3ea819f2 h1:n+fnT6bc9mO8KEytDsHIJiVnX+cSBumlgoK/xTfl7H8=
+github.com/nestybox/sysbox-libs/formatter v0.0.0-20210524172525-ee7d3ea819f2 h1:W88HG3ufy3GLTNgtRcnbbup6BpAdF2abQqEOtazPF3U=
+github.com/nestybox/sysbox-libs/formatter v0.0.0-20210524172525-ee7d3ea819f2/go.mod h1:/ILpO0gYqOe73l4elvX2Jvrnym4ePdIcnKlPZmYCRcY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -742,18 +742,12 @@ func (p *initProcess) setupDevSubdir() error {
 	// some cases (e.g., k8s "pause" container) they do not.
 	devSubdir := filepath.Join(p.config.Config.Rootfs, "dev")
 
-	// The dir mode must match the corresponding mode in libsysbox/spec/spec.go
+	// The dir mode must match the corresponding mode in libsysbox/spec/spec.go.
+	// See that there is no need to chown() this dir to match the container's
+	// root uid & gid as we are expecting a tmpfs mount over this node to take
+	// care of that.
 	if err := os.MkdirAll(devSubdir, 0755); err != nil {
 		return newSystemErrorWithCause(err, "creating dev subdir under rootfs")
-	}
-
-	// The dir owner must match the container's root user uid & gid
-	if p.config.Config.UidMappings != nil && p.config.Config.GidMappings != nil {
-		uid := p.config.Config.UidMappings[0].HostID
-		gid := p.config.Config.GidMappings[0].HostID
-		if err := os.Chown(devSubdir, uid, gid); err != nil {
-			return newSystemErrorWithCause(err, "chown dev subdir under rootfs")
-		}
 	}
 
 	return nil


### PR DESCRIPTION
The issue being fixed here is reproduced in Sysbox-CE deployments when a user attempts to launch a sys-container whose image has been previously built with Sysbox-EE. In these cases, the Sysbox-EE image may be comprised of overlayfs-layers whose individual elements (i.e., posix files) present a UID/GID with a value that falls outside the Sysbox-CE typical range (0-65k). When this happens Sysbox is unable to pull these images and the following log ends up being generated:

```
root@sysbox-test:~/nestybox/sysbox# docker pull ghcr.io/nestybox/k8s-node:v1.20.2
v1.20.2: Pulling from nestybox/k8s-node
f08d8e2a3ba1: Pull complete
3baa9cb2483b: Pull complete
94e5ff4c0b15: Pull complete
1860925334f9: Pull complete
2b6b0be24b95: Pull complete
36dacce76ac9: Extracting [==================================================>]  146.2MB/146.2MB
b38bfefa4027: Download complete
1947c2a10d53: Download complete
9a19c54e5f9a: Download complete
ac81acd851e8: Download complete
ce649af1940c: Download complete
failed to register layer: Error processing tar file(exit status 1): Container ID 231072 cannot be mapped to a host ID
```

What this error log indicates is that Docker is unable to handle an image component whose owner (UID) falls beyond the expected 0-65k range. So the obvious question: where is this '231072' UID coming from?

This UID was explicitly associated with the rootfs' "/dev" directory by the Sysbox-EE's runc binary during the image-building process, and it corresponds to the root's UID/GID value assigned by Sysbox (mgr) to the specific sys-container that created that particular image layer.

The bug here lies within sysbox-runc when it sets this '231072' UID by chown()ing the "/dev" folder, to ensure that this one is displayed with the proper permissions within the sys-container. However, there is no need for this chown() operation as a "tmpfs" file-system is always bind-mounted by sysbox-runc over the "/dev" resource. This "tmpfs" bind-mount operation explicitly sets the root UID/GID value (231072), which voids the need for the chown() instruction, so the fix here is to simply eliminate this operation.

This bug can potentially affect all those docker images that have been built making use of Sysbox, AND, that have an image layer with changes in the "/dev" node. This typically happens when users make sysbox the default runtime to build compounded docker images (i.e., images that contain inner container images), AND there's at least one operation that modifies the "/dev" node (e.g., "apt-get update" which does a chown()).

[ PR internally reviewed ]

Signed-off-by: Rodny Molina <rmolina@nestybox.com>