### PR TITLE
Fix make static error due to missing -ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 GO_BUILD := $(GO) build $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
 	-ldflags $(LDFLAGS) $(EXTRA_LDFLAGS)
 GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
-	-ldflags "-w -extldflags -static" $(LDFLAGS) $(EXTRA_LDFLAGS)
+	-ldflags "-w -extldflags -static" -ldflags $(LDFLAGS) $(EXTRA_LDFLAGS)
 GO_BUILD_DEBUG := $(GO) build --buildmode=exe $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
 	-ldflags $(LDFLAGS) $(EXTRA_LDFLAGS) -gcflags="all=-N -l"
 


### PR DESCRIPTION
fix build error
`CGO_ENABLED=1 go build -o sysbox-runc  -tags "seccomp netgo osusergo" -ldflags "-w -extldflags -static" ' -X main.version=0.3.0 -X main.commitId=df952e5276cb6e705e0be331e9a9fe88f372eab8-dirty -X "main.builtAt=Fri Jul  2 15:36:25 UTC 2021" -X "main.builtBy=Your Name"'   .
can't load package: package  -X main.version=0.3.0 -X main.commitId=df952e5276cb6e705e0be331e9a9fe88f372eab8-dirty -X "main.builtAt=Fri Jul  2 15:36:25 UTC 2021" -X "main.builtBy=Your Name": malformed module path " -X main.version=0.3.0 -X main.commitId=df952e5276cb6e705e0be331e9a9fe88f372eab8-dirty -X \"main.builtAt=Fri Jul  2 15:36:25 UTC 2021\" -X \"main.builtBy=Your Name\"": invalid char ' '
make[1]: *** [Makefile:97: static] Error 1
make: *** [Makefile:174: sysbox-runc-static] Error 2
make: *** [Makefile:158: sysbox-static] Error 2`