### PR TITLE
Fix bug in remount flags.

### DIFF
--- a/libcontainer/rootfs_init_linux.go
+++ b/libcontainer/rootfs_init_linux.go
@@ -265,7 +265,8 @@ func (l *linuxRootfsInit) Init() error {
 			if m.Flags&^(unix.MS_REC|unix.MS_REMOUNT|unix.MS_BIND) != 0 {
 				// only remount if unique mount options are set
 				if err := remount(m); err != nil {
-					return newSystemErrorWithCausef(err, "remount %s to %s", m.Source, m.Destination)
+					return newSystemErrorWithCausef(err, "remount of %s with flags %#x",
+						m.Destination, m.Flags)
 				}
 			}
 

--- a/libsysbox/sysbox/mgr.go
+++ b/libsysbox/sysbox/mgr.go
@@ -48,8 +48,8 @@ func (mgr *Mgr) Enabled() bool {
 	return mgr.Active
 }
 
-// Registers the container with sysbox-mgr. If successful, returns
-// configuration tokens for sysbox-runc.
+// Registers the container with sysbox-mgr. If successful, stores the
+// sysbox configuration tokens for sysbox-runc in mgr.Config
 func (mgr *Mgr) Register(spec *specs.Spec) error {
 	var userns string
 	var netns string


### PR DESCRIPTION
Per mount(2), a remount operation must keep the original flags
of the mount, except for those that are being changed during
the remount operation.

The remount() function in rootfs_linux.go was not honoring this
requirement, causing remounts to fail in cases where the
filesystem was mounted had non-standard flags. This commit
fixes this.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>