### PR TITLE
Ensure sysbox mounts in read-only containers are mounted as read only.

### DIFF
--- a/libcontainer/mount/mount.go
+++ b/libcontainer/mount/mount.go
@@ -14,21 +14,25 @@ func GetMountsPid(pid uint32) ([]*Info, error) {
 	return parseMountTableForPid(pid)
 }
 
+func FindMount(mountpoint string, mounts []*Info) bool {
+	for _, m := range mounts {
+		if m.Mountpoint == mountpoint {
+			return true
+		}
+	}
+	return false
+}
+
 // Mounted looks at /proc/self/mountinfo to determine if the specified
 // mountpoint has been mounted
 func Mounted(mountpoint string) (bool, error) {
-	entries, err := parseMountTable()
+	mounts, err := parseMountTable()
 	if err != nil {
 		return false, err
 	}
 
-	// Search the table for the mountpoint
-	for _, e := range entries {
-		if e.Mountpoint == mountpoint {
-			return true, nil
-		}
-	}
-	return false, nil
+	isMounted := FindMount(mountpoint, mounts)
+	return isMounted, nil
 }
 
 // MountedWithFs looks at /proc/self/mountinfo to determine if the specified


### PR DESCRIPTION
In containers that have a read-only rootfs (e.g., docker run --read-only ...),
we must ensure that sysbox's implicit mounts are also read-only. Prior to this
change this was not the case, enabling processes inside the read-only container
to write to portions of the container's filesystem backed by sysbox mounts.

This commit fixes this and adds a test to verify the fix. The fix is not yet
complete, as the sysbox-fs mount over the container's "/proc/sys" continues to
be read-write, even though it was remounted read-only.  We will investigate and
fix in a later commit.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>