### PR TITLE
Query sysbox-fs for it's fuse mountpoint config.

### DIFF
--- a/create.go
+++ b/create.go
@@ -96,6 +96,13 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			}()
 		}
 
+		// Get sysbox-fs related configs
+		if sysFs.Enabled() {
+			if err = sysFs.GetConfig(); err != nil {
+				return err
+			}
+		}
+
 		uidShiftSupported, uidShiftRootfs, err = syscont.ConvertSpec(context, sysMgr, sysFs, spec)
 		if err != nil {
 			return fmt.Errorf("error in the container spec: %v", err)

--- a/libsysbox/sysbox/fs.go
+++ b/libsysbox/sysbox/fs.go
@@ -39,10 +39,11 @@ type FsRegInfo struct {
 }
 
 type Fs struct {
-	Active bool
-	Id     string // container-id
-	PreReg bool   // indicates if the container was pre-registered with sysbox-fs
-	Reg    bool   // indicates if sys container was registered with sysbox-fs
+	Active     bool
+	Id         string // container-id
+	PreReg     bool   // indicates if the container was pre-registered with sysbox-fs
+	Reg        bool   // indicates if sys container was registered with sysbox-fs
+	Mountpoint string // sysbox-fs FUSE mountpoint
 }
 
 func NewFs(id string, enable bool) *Fs {
@@ -54,6 +55,17 @@ func NewFs(id string, enable bool) *Fs {
 
 func (fs *Fs) Enabled() bool {
 	return fs.Active
+}
+
+func (fs *Fs) GetConfig() error {
+
+	mp, err := sysboxFsGrpc.GetMountpoint()
+	if err != nil {
+		return fmt.Errorf("failed to get config from sysbox-fs: %v", err)
+	}
+
+	fs.Mountpoint = mp
+	return nil
 }
 
 // Pre-registers container with sysbox-fs.

--- a/libsysbox/syscont/spec.go
+++ b/libsysbox/syscont/spec.go
@@ -35,14 +35,17 @@ import (
 
 // Exported
 const (
-	SysboxFsDir string = "/var/lib/sysboxfs"
-	IdRangeMin  uint32 = 65536
+	IdRangeMin uint32 = 65536
 )
 
 // Internal
 const (
 	defaultUid uint32 = 231072
 	defaultGid uint32 = 231072
+)
+
+var (
+	SysboxFsDir string = "/var/lib/sysboxfs"
 )
 
 // System container "must-have" mounts
@@ -595,7 +598,7 @@ func cfgSysboxFsMounts(spec *specs.Spec, sysFs *sysbox.Fs) {
 	})
 
 	// Adjust sysboxFsMounts path attending to container-id value.
-	cntrMountpoint := filepath.Join(SysboxFsDir, sysFs.Id)
+	cntrMountpoint := filepath.Join(sysFs.Mountpoint, sysFs.Id)
 
 	for i := range sysboxFsMounts {
 		sysboxFsMounts[i].Source =
@@ -606,6 +609,8 @@ func cfgSysboxFsMounts(spec *specs.Spec, sysFs *sysbox.Fs) {
 				1,
 			)
 	}
+
+	SysboxFsDir = sysFs.Mountpoint
 
 	// If the spec indicates a read-only rootfs, the sysbox-fs mounts should also
 	// be read-only. However, we don't mark them read-only here explicitly, so

--- a/restore.go
+++ b/restore.go
@@ -134,6 +134,13 @@ using the sysbox-runc checkpoint command.`,
 			}()
 		}
 
+		// Get sysbox-fs related configs
+		if sysFs.Enabled() {
+			if err = sysFs.GetConfig(); err != nil {
+				return err
+			}
+		}
+
 		uidShiftSupported, uidShiftRootfs, err = syscont.ConvertSpec(context, sysMgr, sysFs, spec)
 		if err != nil {
 			return fmt.Errorf("error in the container spec: %v", err)

--- a/run.go
+++ b/run.go
@@ -122,6 +122,13 @@ command(s) that get executed on start, edit the args parameter of the spec. See
 			}()
 		}
 
+		// Get sysbox-fs related configs
+		if sysFs.Enabled() {
+			if err = sysFs.GetConfig(); err != nil {
+				return err
+			}
+		}
+
 		uidShiftSupported, uidShiftRootfs, err = syscont.ConvertSpec(context, sysMgr, sysFs, spec)
 		if err != nil {
 			return fmt.Errorf("error in the container spec: %v", err)


### PR DESCRIPTION
This change causes sysbox-runc to query sysbox-fs for the location of the fuse
mountpoint.

Prior to this change, sysbox-runc was assuming the sysbox-fs fuse mountpoint was
located under host directory "/var/lib/sysboxfs", but this may not always be
true given that it's configurable in the sysbox-fs command line.

Fixes Sysbox issue #319.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>