### PR TITLE
Fix build with GOFLAGS="-mod=readonly" (default in Go 1.16+)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/nestybox/sysbox-ipc v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/capability v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/dockerUtils v0.0.0-00010101000000-000000000000
+	github.com/nestybox/sysbox-libs/formatter v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/libseccomp-golang v0.0.0-00010101000000-000000000000
 	github.com/nestybox/sysbox-libs/utils v0.0.0-00010101000000-000000000000
 	github.com/opencontainers/runc v0.0.0-00010101000000-000000000000
@@ -42,5 +43,7 @@ replace github.com/nestybox/sysbox-libs/capability => ../sysbox-libs/capability
 replace github.com/nestybox/sysbox-libs/utils => ../sysbox-libs/utils
 
 replace github.com/nestybox/sysbox-libs/dockerUtils => ../sysbox-libs/dockerUtils
+
+replace github.com/nestybox/sysbox-libs/formatter => ../sysbox-libs/formatter
 
 replace github.com/opencontainers/runc => ./

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,6 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/nestybox/sysbox-libs v0.0.0-20210524172525-ee7d3ea819f2 h1:n+fnT6bc9mO8KEytDsHIJiVnX+cSBumlgoK/xTfl7H8=
-github.com/nestybox/sysbox-libs/formatter v0.0.0-20210524172525-ee7d3ea819f2 h1:W88HG3ufy3GLTNgtRcnbbup6BpAdF2abQqEOtazPF3U=
-github.com/nestybox/sysbox-libs/formatter v0.0.0-20210524172525-ee7d3ea819f2/go.mod h1:/ILpO0gYqOe73l4elvX2Jvrnym4ePdIcnKlPZmYCRcY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=


### PR DESCRIPTION
When building sysbox-runc, the build depends on the Golang import lookup feature to resolve the internal sysbox-libs/formatter module, the following lines are shown on the log when building with "make sysbox":

```
go: finding github.com/nestybox/sysbox-libs latest
go: finding github.com/nestybox/sysbox-libs/formatter latest
```

(It appears to be downloading the latest version which may cause flakyness?)

If using GOFLAGS="-mod=readonly" (default in Go 1.16+), the build fails with:

```
build github.com/nestybox/sysbox-runc: cannot load github.com/nestybox/sysbox-libs/formatter: import lookup disabled by -mod=readonly
```

Explicitly use the local sysbox-libs/formatter module (similarly to sysbox-libs/dockerUtils) to avoid this problem.
