### PR TITLE
Fix bug in function that creates dirs under the container's rootfs.

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -1321,7 +1321,7 @@ func (c *linuxContainer) makeCriuRestoreMountpoints(m *configs.Mount) error {
 		// sysbox-runc: this is no longer the case; prepareBindDest() only checks the
 		// mount destination; if we need to check the mount source we need to create a
 		// function that explicitly does this.
-		if err := prepareBindDest(m, c.config.Rootfs, true); err != nil {
+		if err := prepareBindDest(m, true, c.config, nil); err != nil {
 			return err
 		}
 	default:
@@ -2343,7 +2343,7 @@ func (c *linuxContainer) handleReqOp(childPid int, reqs []opReq) error {
 	// of the same type.
 	op := reqs[0].Op
 
-	if op != bind && op != switchDockerDns && op != chown {
+	if op != bind && op != switchDockerDns && op != chown && op != mkdir {
 		return newSystemError(fmt.Errorf("invalid opReq type %d", int(op)))
 	}
 
@@ -2389,12 +2389,10 @@ func (c *linuxContainer) handleOp(op opReqType, childPid int, reqs []opReq) erro
 	var nsPath string
 
 	switch op {
-	case bind:
+	case bind, chown, mkdir:
 		nsPath = fmt.Sprintf("mnt:/proc/%d/ns/mnt", childPid)
 	case switchDockerDns:
 		nsPath = fmt.Sprintf("net:/proc/%d/ns/net", childPid)
-	case chown:
-		nsPath = fmt.Sprintf("mnt:/proc/%d/ns/mnt", childPid)
 	}
 
 	namespaces := []string{nsPath}

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -38,6 +38,7 @@ const (
 	switchDockerDns
 	seccompFd
 	chown
+	mkdir
 )
 
 type opReq struct {
@@ -52,10 +53,11 @@ type opReq struct {
 	OldDns string `json:"olddns"`
 	NewDns string `json:"newdns"`
 
-	// chown
-	Path string `json:"path"`
-	Uid  int    `json:"uid"`
-	Gid  int    `json:"gid"`
+	// chown & mkdir
+	Path string      `json:"path"`
+	Uid  int         `json:"uid"`
+	Gid  int         `json:"gid"`
+	Mode os.FileMode `json:"mode"`
 }
 
 func (l *linuxStandardInit) getSessionRingParams() (string, uint32, uint32) {


### PR DESCRIPTION
When running a container with CRI-O + Sysbox (i.e., with the user-namespace
enabled), CRI-O typically configures the ownership of the container's
rootfs to match the UID assigned to the container.

However, CRI-O skips this ownership config for subdirs of the container's rootfs
marked as mountpoints in the image file (e.g., via the Dockerfile VOLUME
instruction).

As a result, when the container is being created and in cases where the
container's init process needs to crete a subdir inside the container rootfs,
it's possible that it won't have the permissions to do so (i.e., the container's
init process runs with a non-root UID, yet the image has root ownership in the
parent dir because is designated as a mountpoint). This causes the container to
fail to start.

This change fixes this by having the parent sysbox-runc process (which runs as
root) create the rootfs subdirs, in cases where the container's init process
lacks the permissions to do so.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>