### PR TITLE
Add close_range() syscall to seccomp whitelist.

### DIFF
--- a/libsysbox/syscont/syscalls.go
+++ b/libsysbox/syscont/syscalls.go
@@ -354,6 +354,7 @@ var syscontSyscallWhitelist = []string{
 	"pivot_root",
 	"gethostname",
 	"sethostname",
+	"close_range",
 
 	// allow namespace creation inside the system container (for nested containers)
 	"setns",


### PR DESCRIPTION
This is required to enable running web based destkop environments
inside sysbox containers using https://github.com/linuxserver/docker-webtop.

Without this, launching a bash terminal inside the sysbox container fails.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>