### PR TITLE
Apply effect of --honor-caps config and add support for SYSBOX_HONOR_CAPS env var.

### DIFF
--- a/libsysbox/syscont/utils.go
+++ b/libsysbox/syscont/utils.go
@@ -185,10 +185,10 @@ func rootfsCloningRequired(rootfs string) (bool, error) {
 	return false, nil
 }
 
-// parseSysboxEnvVar parses the container's env vars for the given variable and
-// returns the triplet (found, value, error).
-func parseSysboxEnvVar(spec *specs.Spec, envVar string) (bool, string, error) {
-	for _, ev := range spec.Process.Env {
+// parseSysboxEnvVar parses the container's process env vars for the given
+// variable and returns the triplet (found, value, error).
+func parseSysboxEnvVar(p *specs.Process, envVar string) (bool, string, error) {
+	for _, ev := range p.Env {
 		if strings.HasPrefix(ev, envVar+"=") {
 			tokens := strings.Split(ev, "=")
 			if len(tokens) != 2 {


### PR DESCRIPTION
This commit applies the effect of the sysbox-mgr's --honor-caps command line
flag on containers. It also adds a per-container override via the container env
var SYSBOX_HONOR_CAPS.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>