### PR TITLE
Mitigate symlink exchanges attacks in Sysbox

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2474,6 +2474,7 @@ func (c *linuxContainer) handleOp(op opReqType, childPid int, reqs []opReq) erro
 	case bind, chown, mkdir:
 		namespaces = append(namespaces,
 			fmt.Sprintf("mnt:/proc/%d/ns/mnt", childPid),
+			fmt.Sprintf("pid:/proc/%d/ns/pid", childPid),
 		)
 	case switchDockerDns:
 		namespaces = append(namespaces,

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -29,8 +29,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/runc/libcontainer/utils"
-	libcontainerUtils "github.com/opencontainers/runc/libcontainer/utils"
-
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
@@ -42,7 +40,7 @@ const defaultMountFlags = unix.MS_NOEXEC | unix.MS_NOSUID | unix.MS_NODEV
 // needsSetupDev returns true if /dev needs to be set up.
 func needsSetupDev(config *configs.Config) bool {
 	for _, m := range config.Mounts {
-		if m.Device == "bind" && libcontainerUtils.CleanPath(m.Destination) == "/dev" {
+		if m.Device == "bind" && utils.CleanPath(m.Destination) == "/dev" {
 			return false
 		}
 	}
@@ -142,7 +140,7 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig) (err error) {
 func finalizeRootfs(config *configs.Config) (err error) {
 	// remount dev as ro if specified
 	for _, m := range config.Mounts {
-		if libcontainerUtils.CleanPath(m.Destination) == "/dev" {
+		if utils.CleanPath(m.Destination) == "/dev" {
 			if m.Flags&unix.MS_RDONLY == unix.MS_RDONLY {
 				if err := remountReadonly(m); err != nil {
 					return newSystemErrorWithCausef(err, "remounting %q as readonly", m.Destination)
@@ -415,7 +413,7 @@ func mountToRootfs(m *configs.Mount, config *configs.Config, enableCgroupns bool
 	// sysbox-runc: use relative path for the rootfs as we may not have access to it via the abs path.
 	rootfs := "."
 
-	// Verify the mount destination is within the container's rootfs
+	// Ensure the mount destination is within the container's rootfs
 	dest, err := securejoin.SecureJoin(rootfs, m.Destination)
 	if err != nil {
 		return err
@@ -1112,7 +1110,7 @@ func mountPropagate(m *configs.Mount, rootfs string, mountLabel string) error {
 	// operations on it. We need to set up files in "/dev" and tmpfs mounts may
 	// need to be chmod-ed after mounting. The mount will be remounted ro later
 	// in finalizeRootfs() if necessary.
-	if libcontainerUtils.CleanPath(m.Destination) == "/dev" || m.Device == "tmpfs" {
+	if utils.CleanPath(m.Destination) == "/dev" || m.Device == "tmpfs" {
 		flags &= ^unix.MS_RDONLY
 	}
 

--- a/libcontainer/utils/utils.go
+++ b/libcontainer/utils/utils.go
@@ -2,12 +2,15 @@ package utils
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"unsafe"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"golang.org/x/sys/unix"
 )
 
@@ -71,6 +74,74 @@ func CleanPath(path string) string {
 
 	// Clean the path again for good measure.
 	return filepath.Clean(path)
+}
+
+// StripRoot returns the passed path, stripping the root path if it was
+// (lexicially) inside it. Note that both passed paths will always be treated
+// as absolute, and the returned path will also always be absolute. In
+// addition, the paths are cleaned before stripping the root.
+func StripRoot(root, path string) string {
+	// Make the paths clean and absolute.
+	root, path = CleanPath("/"+root), CleanPath("/"+path)
+	switch {
+	case path == root:
+		path = "/"
+	case root == "/":
+		// do nothing
+	case strings.HasPrefix(path, root+"/"):
+		path = strings.TrimPrefix(path, root+"/")
+	}
+	return CleanPath("/" + path)
+}
+
+// WithProcfd runs the passed closure with a procfd path (/proc/self/fd/...)
+// corresponding to the unsafePath resolved within the root. Before passing the
+// fd, this path is verified to have been inside the root -- so operating on it
+// through the passed fdpath should be safe. Do not access this path through
+// the original path strings, and do not attempt to use the pathname outside of
+// the passed closure (the file handle will be freed once the closure returns).
+func WithProcfd(root, unsafePath string, fn func(procfd string) error) error {
+
+	// Remove the root then forcefully resolve inside the root.
+	relUnsafePath := StripRoot(root, unsafePath)
+	path, err := securejoin.SecureJoin(root, relUnsafePath)
+	if err != nil {
+		return fmt.Errorf("resolving path inside rootfs failed: %v", err)
+	}
+
+	// Open the target path.
+	fh, err := os.OpenFile(path, unix.O_PATH|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open o_path procfd: %w", err)
+	}
+	defer fh.Close()
+
+	// Double-check the path is the one we expected.
+	procfd := "/proc/self/fd/" + strconv.Itoa(int(fh.Fd()))
+	realpath, err := os.Readlink(procfd)
+	if err != nil {
+		return err
+	}
+
+	// The realPath has the absolute path; if root is cwd, then we need the relative path
+	if root == "." {
+		rootAbs, err := os.Readlink("/proc/self/cwd")
+		if err != nil {
+			return err
+		}
+		if !strings.HasSuffix(rootAbs, "/") {
+			rootAbs = rootAbs + "/"
+		}
+		realpath = strings.TrimPrefix(realpath, rootAbs)
+	}
+
+	// Verify the path string and /proc/self/fd match
+	if realpath != path {
+		return fmt.Errorf("possibly malicious path detected -- refusing to operate on %s", realpath)
+	}
+
+	// Run the closure.
+	return fn(procfd)
 }
 
 // SearchLabels searches a list of key-value pairs for the provided key and

--- a/libsysbox/shiftfs/shiftfs.go
+++ b/libsysbox/shiftfs/shiftfs.go
@@ -24,6 +24,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const SHIFTFS_MAGIC int64 = 0x6a656a62
+
 // Mark performs a shiftfs mark-mount for path on the given markPath
 // (e.g., Mark("/a/b", "/c/d") causes "b" to be mounted on "d" and
 // "d" to have a shiftfs mark).


### PR DESCRIPTION
Changes to mitigate bind-mount "symlink exchange" attacks in Sysbox. See [here](http://blog.champtar.fr/runc-symlink-CVE-2021-30465/) for a description of  such an attack on the OCI runc and [here](https://github.com/opencontainers/runc/commit/0ca91f44f1664da834bc61115a849b56d22f595f) for the original fix in the OCI runc. 

For Sysbox, the fix is similar to the one on the OCI runc, but I had to adjust it to things that are specific to Sysbox (e.g., shiftfs, etc.).

