### PR TITLE
Don't assign more capabilities to the container than those given to Sysbox itself.

### DIFF
--- a/libsysbox/syscont/example.go
+++ b/libsysbox/syscont/example.go
@@ -23,6 +23,11 @@ import (
 // Example returns an example OCI spec file for a system container
 func Example() (*specs.Spec, error) {
 
+	sysboxCaps, err := getSysboxEffCaps()
+	if err != nil {
+		return nil, err
+	}
+
 	return &specs.Spec{
 		Version: specs.Version,
 		Root: &specs.Root{
@@ -45,11 +50,11 @@ func Example() (*specs.Spec, error) {
 			Cwd:             "/",
 			NoNewPrivileges: true,
 			Capabilities: &specs.LinuxCapabilities{
-				Bounding:    linuxCaps,
-				Permitted:   linuxCaps,
-				Inheritable: linuxCaps,
-				Ambient:     linuxCaps,
-				Effective:   linuxCaps,
+				Bounding:    sysboxCaps,
+				Permitted:   sysboxCaps,
+				Inheritable: sysboxCaps,
+				Ambient:     sysboxCaps,
+				Effective:   sysboxCaps,
 			},
 			Rlimits: []specs.POSIXRlimit{
 				{


### PR DESCRIPTION
Prior to this commit, sysbox-runc would assign sys containers all capabilities supported by the host kernel. This is not technically correct, as Sysbox should never assign a container process more capabilities than it itself has.

So when would Sysbox not run will all kernel capabilities? It can happen when Sysbox runs inside a privileged container for example, if the Docker version at host level does not yet support all the kernel's capabilities (i.e., Docker won't assign Sysbox all the kernel capabilities, but rather only the ones it knows about).

If such a scenario occurs, without this fix Sysbox won't work properly as it will run the container with more capabilities that it has itself. For example, sysbox-fs will hit EPERMs when it tries to adopt a container's process capabilities during syscall processing, because the container has more capabilities than sysbox-fs itself has.

This commit fixes this by ensuring sysbox-runc never assigns a container more capabilities than it has itself.