### PR TITLE
Fix bug in chown of sysbox's implicit mounts.

### DIFF
--- a/libsysbox/sysbox/mgr.go
+++ b/libsysbox/sysbox/mgr.go
@@ -134,8 +134,8 @@ func (mgr *Mgr) PrepMounts(uid, gid uint32, prepList []ipcLib.MountPrepInfo) err
 }
 
 // ReqMounts sends a request to sysbox-mgr for container mounts; all paths must be absolute.
-func (mgr *Mgr) ReqMounts(uid, gid uint32, reqList []ipcLib.MountReqInfo) ([]specs.Mount, error) {
-	mounts, err := sysboxMgrGrpc.ReqMounts(mgr.Id, uid, gid, reqList)
+func (mgr *Mgr) ReqMounts(rootfsUidShiftType sh.IDShiftType, reqList []ipcLib.MountReqInfo) ([]specs.Mount, error) {
+	mounts, err := sysboxMgrGrpc.ReqMounts(mgr.Id, rootfsUidShiftType, reqList)
 	if err != nil {
 		return nil, fmt.Errorf("failed to request mounts from sysbox-mgr: %v", err)
 	}
@@ -164,6 +164,13 @@ func (mgr *Mgr) ReqFsState(rootfs string) ([]configs.FsEntry, error) {
 func (mgr *Mgr) Pause() error {
 	if err := sysboxMgrGrpc.Pause(mgr.Id); err != nil {
 		return fmt.Errorf("failed to notify pause to sysbox-mgr: %v", err)
+	}
+	return nil
+}
+
+func (mgr *Mgr) Resume() error {
+	if err := sysboxMgrGrpc.Resume(mgr.Id); err != nil {
+		return fmt.Errorf("failed to notify resume to sysbox-mgr: %v", err)
 	}
 	return nil
 }

--- a/libsysbox/sysbox/sysbox.go
+++ b/libsysbox/sysbox/sysbox.go
@@ -232,8 +232,8 @@ func CheckUidShifting(sysMgr *Mgr, spec *specs.Spec) (sh.IDShiftType, sh.IDShift
 
 		// Check uid shifting type to be used for the container's rootfs.
 		//
-		// We do it via ID-mapping (preferably), or via shiftfs (if available on
-		// the host), or by chown'ing the rootfs hierarchy. Chowning is the least
+		// We do it via ID-mapping (preferably) or via shiftfs (if available on
+		// the host) or by chown'ing the rootfs hierarchy. Chowning is the least
 		// preferred and slowest approach, but won't disrupt anything on the host
 		// since the container's rootfs is dedicated to the container (no other
 		// entity in the system will use it while the container is running).


### PR DESCRIPTION
The prior code was not handling correctly the chown of Sysbox's implicit container mounts (e.g., /var/lib/docker, /var/lib/kubelet, etc) during container stop/restart and pause/resume, across the different combinations of ID-mapping, shiftfs, rootfs cloning, and docker userns-remap.

This commit, together with a corresponding one in sysbox-mgr, fixes this.