### PR TITLE
Fix ordering of mounts under /run for containers with systemd.

### DIFF
--- a/libsysbox/syscont/spec.go
+++ b/libsysbox/syscont/spec.go
@@ -520,11 +520,13 @@ func cfgMounts(spec *specs.Spec, sysbox *sysbox.Sysbox) error {
 		}
 	}
 
+	hasSystemd := false
 	if systemdInit(spec.Process) && sysMgr.Config.SyscontMode {
+		hasSystemd = true
 		cfgSystemdMounts(spec)
 	}
 
-	sortMounts(spec)
+	sortMounts(spec, hasSystemd)
 
 	return nil
 }

--- a/libsysbox/syscont/spec_test.go
+++ b/libsysbox/syscont/spec_test.go
@@ -239,47 +239,6 @@ func TestCfgReadonlyPaths(t *testing.T) {
 	}
 }
 
-func TestSortMounts(t *testing.T) {
-
-	spec := new(specs.Spec)
-
-	spec.Mounts = []specs.Mount{
-		{Destination: "/dev", Type: "tmpfs"},
-		{Destination: "/proc/swaps", Type: "bind"},
-		{Destination: "/proc", Type: "proc"},
-		{Destination: "/var/lib/docker/overlay2", Type: "bind"},
-		{Destination: "/var/lib/docker", Type: "bind"},
-		{Destination: "/var/lib/docker/overlay2/diff", Type: "bind"},
-		{Destination: "/tmp/run", Type: "tmpfs"},
-		{Destination: "/sys/fs/cgroup", Type: "cgroup"},
-		{Destination: "/sys", Type: "sysfs"},
-		{Destination: "/tmp/run2", Type: "tmpfs"},
-	}
-
-	wantMounts := []specs.Mount{
-		{Destination: "/sys", Type: "sysfs"},
-		{Destination: "/sys/fs/cgroup", Type: "cgroup"},
-		{Destination: "/proc", Type: "proc"},
-		{Destination: "/dev", Type: "tmpfs"},
-		{Destination: "/tmp/run", Type: "tmpfs"},
-		{Destination: "/tmp/run2", Type: "tmpfs"},
-
-		// bind mounts should be grouped at the end; bind mounts
-		// dependent on others must be placed after those others.
-
-		{Destination: "/proc/swaps", Type: "bind"},
-		{Destination: "/var/lib/docker", Type: "bind"},
-		{Destination: "/var/lib/docker/overlay2", Type: "bind"},
-		{Destination: "/var/lib/docker/overlay2/diff", Type: "bind"},
-	}
-
-	sortMounts(spec)
-
-	if !utils.MountSliceEqual(spec.Mounts, wantMounts) {
-		t.Errorf("sortMounts() failed: got %v, want %v", spec.Mounts, wantMounts)
-	}
-}
-
 func TestCfgSystemd(t *testing.T) {
 
 	spec := new(specs.Spec)

--- a/libsysbox/syscont/utils.go
+++ b/libsysbox/syscont/utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 // sortMounts sorts the sys container mounts in the given spec.
-func sortMounts(spec *specs.Spec) {
+func sortMounts(spec *specs.Spec, hasSystemd bool) {
 
 	// The OCI spec requires the runtime to honor the ordering on
 	// mounts in the spec. However, we deviate a bit and always order
@@ -37,6 +37,10 @@ func sortMounts(spec *specs.Spec) {
 		"/sys":  1,
 		"/proc": 2,
 		"/dev":  3,
+	}
+
+	if hasSystemd {
+		orderList["/run"] = 4
 	}
 
 	sort.SliceStable(spec.Mounts, func(i, j int) bool {


### PR DESCRIPTION
Fixes Sysbox [issue 767](https://github.com/nestybox/sysbox/issues/767).