### PR TITLE
Allow x86 syscalls

### DIFF
--- a/libsysbox/syscont/syscalls.go
+++ b/libsysbox/syscont/syscalls.go
@@ -403,7 +403,7 @@ func AddSyscallTraps(config *configs.Config) error {
 
 		config.SeccompNotif = &configs.Seccomp{
 			DefaultAction: configs.Allow,
-			Architectures: []string{"amd64", "arm64", "arm"},
+			Architectures: []string{"amd64", "x86", "arm64", "arm"},
 			Syscalls:      list,
 		}
 	}


### PR DESCRIPTION
This allows the execution of 32bit applications on amd64 systems.

Fixes #350 
https://github.com/nestybox/sysbox/issues/350

Test for this is in PR  https://github.com/nestybox/sysbox/pull/789
