### PR TITLE
fix: skip dns change when default route doesn't exists

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -1373,6 +1373,12 @@ func switchDockerDnsIP(config *configs.Config, pipe io.ReadWriter) error {
 		return err
 	}
 
+	// https://github.com/nestybox/sysbox/issues/834
+	// Skip the DNS change if a default gateway isn't available.
+	if defRoute == "" {
+		return nil
+	}
+
 	// Request the parent runc to enter the container's net-ns and change the DNS
 	// in the iptables (can't do this from within the container as we may not
 	// have the required / compatible iptables package in the container).


### PR DESCRIPTION
The problem is described in this issue I created: https://github.com/nestybox/sysbox/issues/834
Looking better at the code I found the problem, and now it behaves normally in this situation checking if the default route exists