### PR TITLE
Add feature to auto-mount binfmt_misc inside the Sysbox container.

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -31,6 +31,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runc/libsysbox/syscont"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
@@ -66,7 +67,7 @@ func prepareRootfs(pipe io.ReadWriter, iConfig *initConfig) (err error) {
 		return newSystemErrorWithCause(err, "effecting rootfs mount")
 	}
 
-	if err := doMounts(config, pipe); err != nil {
+	if err := doMounts(config, pipe, false); err != nil {
 		return newSystemErrorWithCause(err, "setting up rootfs mounts")
 	}
 
@@ -219,6 +220,7 @@ func prepareBindDest(m *configs.Mount, absDestPath bool, config *configs.Config,
 
 	// update the mount with the correct dest after symlinks are resolved.
 	m.Destination = dest
+
 	if err = createIfNotExists(dest, m.BindSrcInfo.IsDir, config, pipe); err != nil {
 		return err
 	}
@@ -501,7 +503,7 @@ func mountToRootfs(m *configs.Mount, config *configs.Config, enableCgroupns bool
 	}
 }
 
-func doBindMounts(config *configs.Config, pipe io.ReadWriter) error {
+func doBindMounts(config *configs.Config, pipe io.ReadWriter, doSysboxfsOvermountsOnly bool) error {
 
 	// sysbox-runc: the sys container's init process is in a dedicated
 	// user-ns, so it may not have search permission to the bind mount
@@ -524,6 +526,12 @@ func doBindMounts(config *configs.Config, pipe io.ReadWriter) error {
 	for _, m := range config.Mounts {
 
 		if m.Device != "bind" {
+			continue
+		}
+
+		isSysboxfsOvermount := isSysboxfsOvermount(m)
+		if doSysboxfsOvermountsOnly && !isSysboxfsOvermount ||
+			!doSysboxfsOvermountsOnly && isSysboxfsOvermount {
 			continue
 		}
 
@@ -582,6 +590,17 @@ func doBindMounts(config *configs.Config, pipe io.ReadWriter) error {
 	}
 
 	return nil
+}
+
+// isSysboxfsOvermount returns true if the given mount destination is under a
+// sysbox-fs managed mountpoint.
+func isSysboxfsOvermount(m *configs.Mount) bool {
+	for _, sysboxfsMount := range syscont.SysboxfsMounts {
+		if strings.HasPrefix(m.Destination, sysboxfsMount.Destination+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 func chownMounts(config *configs.Config, pipe io.ReadWriter, chownList []string) error {
@@ -985,6 +1004,7 @@ func chroot() error {
 
 // createIfNotExists creates a file or a directory only if it does not already exist.
 func createIfNotExists(path string, isDir bool, config *configs.Config, pipe io.ReadWriter) error {
+
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
 			if isDir {
@@ -1179,13 +1199,22 @@ func doRootfsIDMapping(config *configs.Config, pipe io.ReadWriter) error {
 	return nil
 }
 
-// sysbox-runc: doMounts sets up all of the container's mounts as specified in the given config.
-func doMounts(config *configs.Config, pipe io.ReadWriter) error {
+// sysbox-runc: doMounts sets up the container's mounts as specified in the given config.
+// If sysboxfsOvermounts is true, then only mounts on top of sysbox-fs emulated paths are
+// mounted (e.g., mounts under /proc/sys/). Otherwise such mounts are skipped.
+func doMounts(config *configs.Config, pipe io.ReadWriter, doSysboxfsOvermountsOnly bool) error {
 
 	chownList := []string{}
 
 	// Do non-bind mounts
 	for _, m := range config.Mounts {
+
+		isSysboxfsOvermount := isSysboxfsOvermount(m)
+		if doSysboxfsOvermountsOnly && !isSysboxfsOvermount ||
+			!doSysboxfsOvermountsOnly && isSysboxfsOvermount {
+			continue
+		}
+
 		if m.Device != "bind" {
 			if err := mountToRootfs(m, config, true, pipe); err != nil {
 				return newSystemErrorWithCausef(err, "mounting %q to rootfs %q at %q", m.Source, config.Rootfs, m.Destination)
@@ -1207,7 +1236,7 @@ func doMounts(config *configs.Config, pipe io.ReadWriter) error {
 		}
 	}
 
-	if err := doBindMounts(config, pipe); err != nil {
+	if err := doBindMounts(config, pipe, doSysboxfsOvermountsOnly); err != nil {
 		return err
 	}
 

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -96,6 +96,7 @@ func (l *linuxStandardInit) Init() error {
 
 	// initialises the labeling system
 	selinux.GetEnabled()
+
 	if err := prepareRootfs(l.pipe, l.config); err != nil {
 		return err
 	}
@@ -193,6 +194,13 @@ func (l *linuxStandardInit) Init() error {
 				return errors.Wrapf(err, "readonly path %s", path)
 			}
 		}
+	}
+
+	// Do mounts on top of sysbox-fs emulated paths (e.g., mount binfmt_misc on
+	// /proc/sys/fs/binfmt_misc). This has to be done after we've registered with
+	// sysbox-fs since the mountpoint is under a sysbox-fs emulated path.
+	if err := doMounts(l.config.Config, l.pipe, true); err != nil {
+		return errors.Wrap(err, "doing mounts on top of sysbox-fs")
 	}
 
 	// Handle masked paths

--- a/libsysbox/syscont/spec.go
+++ b/libsysbox/syscont/spec.go
@@ -92,7 +92,7 @@ var syscontMounts = []specs.Mount{
 // Container mounts virtualized by sysbox-fs
 //
 // TODO: in the future get these from sysbox-fs via grpc
-var sysboxFsMounts = []specs.Mount{
+var SysboxfsMounts = []specs.Mount{
 	//
 	// procfs mounts
 	//
@@ -532,7 +532,7 @@ func cfgMounts(spec *specs.Spec, sysbox *sysbox.Sysbox) error {
 	}
 
 	if sysFs.Enabled() {
-		cfgSysboxFsMounts(spec, sysFs)
+		cfgSysboxfsMounts(spec, sysFs)
 	}
 
 	if sysMgr.Enabled() {
@@ -644,20 +644,20 @@ func cfgSyscontMountsReadOnly(sysMgr *sysbox.Mgr, spec *specs.Spec) {
 	spec.Mounts = append(spec.Mounts, tmpMounts...)
 }
 
-// cfgSysboxFsMounts adds the sysbox-fs mounts to the container's config.
-func cfgSysboxFsMounts(spec *specs.Spec, sysFs *sysbox.Fs) {
+// cfgSysboxfsMounts adds the sysbox-fs mounts to the container's config.
+func cfgSysboxfsMounts(spec *specs.Spec, sysFs *sysbox.Fs) {
 
-	spec.Mounts = utils.MountSliceRemove(spec.Mounts, sysboxFsMounts, func(m1, m2 specs.Mount) bool {
+	spec.Mounts = utils.MountSliceRemove(spec.Mounts, SysboxfsMounts, func(m1, m2 specs.Mount) bool {
 		return m1.Destination == m2.Destination
 	})
 
-	// Adjust sysboxFsMounts path attending to container-id value.
+	// Adjust SysboxfsMounts path attending to container-id value.
 	cntrMountpoint := filepath.Join(sysFs.Mountpoint, sysFs.Id)
 
-	for i := range sysboxFsMounts {
-		sysboxFsMounts[i].Source =
+	for i := range SysboxfsMounts {
+		SysboxfsMounts[i].Source =
 			strings.Replace(
-				sysboxFsMounts[i].Source,
+				SysboxfsMounts[i].Source,
 				SysboxFsDir,
 				cntrMountpoint,
 				1,
@@ -675,12 +675,12 @@ func cfgSysboxFsMounts(spec *specs.Spec, sysFs *sysbox.Fs) {
 	// remounted to read-only after the container setup completes, right before
 	// starting the container's init process.
 	if spec.Root.Readonly {
-		for _, m := range sysboxFsMounts {
+		for _, m := range SysboxfsMounts {
 			spec.Linux.ReadonlyPaths = append(spec.Linux.ReadonlyPaths, m.Destination)
 		}
 	}
 
-	spec.Mounts = append(spec.Mounts, sysboxFsMounts...)
+	spec.Mounts = append(spec.Mounts, SysboxfsMounts...)
 }
 
 // cfgSystemdMounts adds systemd related mounts to the spec


### PR DESCRIPTION
Starting with kernel 6.7, `binfmt_misc` is namespaced per user-ns. Therefore, it can now be mounted safely into Sysbox containers. 

In this PR we add support for enabling such mounts on the sysbox-runc side. The mount must occur after sysbox-runc has registered the container with sysbox-fs, because the mount occurs on top of a sysbox-fs emulated dir (`/proc/sys/fs/binfmt_misc`). 