### PR TITLE
overlayfs: add overlay mount dispatch and dedicated workdir for idmapped mounts

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2431,11 +2431,12 @@ func (c *linuxContainer) handleReqOp(childPid int, reqs []opReq) error {
 	// of the same type.
 	op := reqs[0].Op
 
-	if op != bind && op != switchDockerDns && op != chown && op != mkdir && op != rootfsIDMap {
+	switch op {
+	case bind, chown, mkdir, overlay, rootfsIDMap, switchDockerDns:
+		return c.handleOp(op, childPid, reqs)
+	default:
 		return newSystemError(fmt.Errorf("invalid opReq type %d", int(op)))
 	}
-
-	return c.handleOp(op, childPid, reqs)
 }
 
 // sysbox-runc: handleOp dispatches a helpter process that enters one or more of
@@ -2477,7 +2478,7 @@ func (c *linuxContainer) handleOp(op opReqType, childPid int, reqs []opReq) erro
 	namespaces := []string{}
 
 	switch op {
-	case bind, chown, mkdir, rootfsIDMap:
+	case bind, chown, mkdir, overlay, rootfsIDMap:
 		namespaces = append(namespaces,
 			fmt.Sprintf("mnt:/proc/%d/ns/mnt", childPid),
 			fmt.Sprintf("pid:/proc/%d/ns/pid", childPid),

--- a/libcontainer/rootfs_init_linux.go
+++ b/libcontainer/rootfs_init_linux.go
@@ -133,6 +133,44 @@ func doBindMount(rootfs string, m *configs.Mount) error {
 	return nil
 }
 
+func doOverlayMount(rootfs string, m *configs.Mount, mountLabel string) error {
+	// Delay mounting the filesystem read-only if we need to do further
+	// operations on it (similar to bind mounts)
+	flags := m.Flags
+	flags &^= unix.MS_RDONLY
+
+	// Mount with procfd to mitigate symlink exchange attacks
+	if err := libcontainerUtils.WithProcfd(rootfs, m.Destination, func(procfd string) error {
+		data := label.FormatMountLabel(m.Data, mountLabel)
+		return unix.Mount(m.Source, procfd, m.Device, uintptr(flags), data)
+	}); err != nil {
+		return fmt.Errorf("overlay mount through procfd of %s -> %s: %w", m.Source, m.Destination, err)
+	}
+
+	// Apply mount propagation flags in a separate WithProcfd() call
+	if err := libcontainerUtils.WithProcfd(rootfs, m.Destination, func(procfd string) error {
+		for _, pflag := range m.PropagationFlags {
+			if err := unix.Mount("", procfd, "", uintptr(pflag), ""); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("change overlay mount propagation through procfd: %w", err)
+	}
+
+	// Remount read-only if necessary
+	if m.Flags&unix.MS_RDONLY != 0 {
+		if err := libcontainerUtils.WithProcfd(rootfs, m.Destination, func(procfd string) error {
+			return unix.Mount("", procfd, "", uintptr(m.Flags|unix.MS_REMOUNT), "")
+		}); err != nil {
+			return fmt.Errorf("remount overlay read-only through procfd: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // Creates an alias for the Docker DNS via iptables.
 func doDockerDnsSwitch(oldDns, newDns string) error {
 	var (
@@ -513,6 +551,31 @@ func (l *linuxRootfsInit) Init() error {
 
 		if err := doDockerDnsSwitch(oldDns, newDns); err != nil {
 			return newSystemErrorWithCausef(err, "Docker DNS switch from %s to %s", oldDns, newDns)
+		}
+
+	case overlay:
+		// The mount requests assume that the process cwd is the rootfs directory
+		rootfs := l.reqs[0].Rootfs
+		if err := unix.Chdir(rootfs); err != nil {
+			return newSystemErrorWithCausef(err, "chdir to rootfs %s", rootfs)
+		}
+
+		// We are in the pid and mount ns of the container's init process; remount
+		// /proc so that it picks up this fact.
+		os.Lstat("/proc")
+		if err := unix.Mount("proc", "/proc", "proc", 0, ""); err != nil {
+			return newSystemErrorWithCause(err, "re-mounting procfs")
+		}
+		defer unix.Unmount("/proc", unix.MNT_DETACH)
+
+		for _, req := range l.reqs {
+			m := &req.Mount
+			mountLabel := req.Label
+
+			// Perform the overlay mount
+			if err := doOverlayMount(rootfs, m, mountLabel); err != nil {
+				return newSystemErrorWithCausef(err, "overlay mounting %s", m.Destination)
+			}
 		}
 
 	case chown:

--- a/libcontainer/rootfs_init_linux.go
+++ b/libcontainer/rootfs_init_linux.go
@@ -306,6 +306,7 @@ func (l *linuxRootfsInit) Init() error {
 			ovfsMntOpts := overlayUtils.GetMountOpt(mi)
 			ovfsUpperLayer := overlayUtils.GetUpperLayer(ovfsMntOpts)
 			ovfsLowerLayers := overlayUtils.GetLowerLayers(ovfsMntOpts)
+			ovfsWorkDir := overlayUtils.GetWorkLayer(ovfsMntOpts)
 
 			// If the ovfs lower layer paths are relative, then find the ovfs dir path
 			// and chdir to it so that the ovfs mount works. Then chdir back after
@@ -378,6 +379,25 @@ func (l *linuxRootfsInit) Init() error {
 			if err := idShiftUtils.ShiftIdsWithChown(ovfsUpperLayer, int32(uid), int32(gid)); err != nil {
 				return newSystemErrorWithCausef(err, "chown overlayfs upper layet at %s", ovfsUpperLayer)
 			}
+
+			// Create a new overlayfs workdir with the same path as the original but
+			// with a "-sysbox" suffix. We can't reuse the original workdir since it's
+			// owned by the entity that set up the rootfs mount (e.g., Docker). Each
+			// overlayfs mount needs a dedicated workdir.
+			newWorkDir := ovfsWorkDir + "-sysbox"
+			if err := os.MkdirAll(newWorkDir, 0700); err != nil {
+				return fmt.Errorf("failed to create overlayfs workdir %s: %s", newWorkDir, err)
+			}
+
+			// Replace the workdir overlayfs mount option with the new workdir.
+			opts := strings.Split(ovfsMntOpts.Opts, ",")
+			for i, opt := range opts {
+				if strings.HasPrefix(opt, "workdir=") {
+					opts[i] = "workdir=" + newWorkDir
+					break
+				}
+			}
+			ovfsMntOpts.Opts = strings.Join(opts, ",")
 
 			if overlayUtils.GetVolatile(ovfsMntOpts) {
 				// overlay has a check in place to prevent mounting "volatile" system twice

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -496,6 +496,25 @@ func mountToRootfs(m *configs.Mount, config *configs.Config, enableCgroupns bool
 			return mountCgroupV2(m, enableCgroupns, config, pipe)
 		}
 		return mountCgroupV1(m, enableCgroupns, config, pipe)
+	case "overlay":
+		// Overlay mounts may require access to paths that the container's init
+		// process may not have permissions to access. We ask the parent runc
+		// process to perform the mount from within the container's mount namespace.
+		if err := mkdirall(dest, 0755, config, pipe); err != nil {
+			return err
+		}
+
+		req := opReq{
+			Op:     overlay,
+			Mount:  *m,
+			Label:  config.MountLabel,
+			Rootfs: config.Rootfs,
+		}
+
+		if err := syncParentDoOp([]opReq{req}, pipe); err != nil {
+			return newSystemErrorWithCause(err, "syncing with parent runc to perform overlay mount")
+		}
+		return nil
 	default:
 		// ensure that the destination of the mount is resolved of symlinks at mount time because
 		// any previous mounts can invalidate the next mount's destination.
@@ -1273,7 +1292,8 @@ func doMounts(config *configs.Config, pipe io.ReadWriter, doSysboxfsOvermountsOn
 
 		if m.Device != "bind" {
 			if err := mountToRootfs(m, config, true, pipe); err != nil {
-				return newSystemErrorWithCausef(err, "mounting %q to rootfs %q at %q", m.Source, config.Rootfs, m.Destination)
+				return newSystemErrorWithCausef(err, "mounting %q to rootfs %q at %q; mount = %+v",
+					m.Source, config.Rootfs, m.Destination, m)
 			}
 
 			// Change ownership of the container's /proc to match the container's

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -32,11 +32,12 @@ type linuxStandardInit struct {
 type opReqType int
 
 const (
-	bind = iota
+	bind opReqType = iota
 	switchDockerDns
 	chown
 	mkdir
 	rootfsIDMap
+	overlay
 )
 
 type opReq struct {


### PR DESCRIPTION
## Summary

Two overlayfs improvements ported from sysbox-ee:

- Support overlay-type mounts in the container mount spec. Required for
  Docker buildx multi-stage builds when using the containerd snapshotter.
  Overlay mounts are now dispatched via the parent runc helper process
  (same pattern as bind mounts), bypassing permission constraints on the
  lower-dir paths.

- Use a dedicated workdir when remounting an overlayfs mount with ID
  mapping. The original workdir is owned by Docker and cannot be reused;
  a new one with a `-sysbox` suffix is created in its place.

## Testing

Validated with Docker buildx multi-stage builds (containerd snapshotter)
inside a Sysbox container, and with the standard sysbox integration test
suite.