### PR TITLE
Support time namespace

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -218,6 +218,9 @@ type Config struct {
 	// When RootlessCgroups is set, cgroups errors are ignored.
 	RootlessCgroups bool `json:"rootless_cgroups,omitempty"`
 
+	// TimeOffsets specifies the offset for supporting time namespaces.
+	TimeOffsets map[string]specs.LinuxTimeOffset `json:"time_offsets,omitempty"`
+
 	// RootfsUidShiftType indicates the type of fs ID shifting to do on the rootfs
 	RootfsUidShiftType sh.IDShiftType `json:"rootfs_uid_shift_type,omitempty"`
 

--- a/libcontainer/configs/namespaces_syscall.go
+++ b/libcontainer/configs/namespaces_syscall.go
@@ -16,6 +16,7 @@ var namespaceInfo = map[NamespaceType]int{
 	NEWUTS:    unix.CLONE_NEWUTS,
 	NEWPID:    unix.CLONE_NEWPID,
 	NEWCGROUP: unix.CLONE_NEWCGROUP,
+	NEWTIME:   unix.CLONE_NEWTIME,
 }
 
 // CloneFlags parses the container's Namespaces options to set the correct

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -128,6 +128,13 @@ func (v *ConfigValidator) cgroupnamespace(config *configs.Config) error {
 			return errors.New("cgroup namespaces aren't enabled in the kernel")
 		}
 	}
+
+	if config.Namespaces.Contains(configs.NEWTIME) {
+		if _, err := os.Stat("/proc/self/timens_offsets"); os.IsNotExist(err) {
+			return errors.New("time namespaces aren't enabled in the kernel")
+		}
+	}
+
 	return nil
 }
 

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2373,6 +2373,18 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 
 	}
 
+	// write boottime and monotonic time ns offsets.
+	if c.config.Namespaces.Contains(configs.NEWTIME) && c.config.TimeOffsets != nil {
+		var offsetSpec bytes.Buffer
+		for clock, offset := range c.config.TimeOffsets {
+			fmt.Fprintf(&offsetSpec, "%s %d %d\n", clock, offset.Secs, offset.Nanosecs)
+		}
+		r.AddData(&Bytemsg{
+			Type:  TimeOffsetsAttr,
+			Value: offsetSpec.Bytes(),
+		})
+	}
+
 	return bytes.NewReader(r.Serialize()), nil
 }
 

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -21,6 +21,7 @@ const (
 	RootlessEUIDAttr uint16 = 27287
 	UidmapPathAttr   uint16 = 27288
 	GidmapPathAttr   uint16 = 27289
+	TimeOffsetsAttr  uint16 = 27292
 
 	// sysbox-runc
 	PrepRootfsAttr     uint16 = 27290

--- a/libcontainer/nsenter/namespace.h
+++ b/libcontainer/nsenter/namespace.h
@@ -28,5 +28,8 @@
 #ifndef CLONE_NEWNET
 #	define CLONE_NEWNET 0x40000000 /* New network namespace */
 #endif
+#ifndef CLONE_NEWTIME
+#	define CLONE_NEWTIME 0x00000080	/* New time namespace */
+#endif
 
 #endif /* NSENTER_NAMESPACE_H */

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -89,6 +89,10 @@ struct nlconfig_t {
 	char *gidmappath;
 	size_t gidmappath_len;
 
+	/* Time NS offsets. */
+	char *timensoffset;
+	size_t timensoffset_len;
+
 	/* sysbox-runc: rootfs prep */
 	uint8_t prep_rootfs; /* boolean */
 	uint8_t make_parent_priv; /* boolean */
@@ -124,6 +128,7 @@ static int logfd = -1;
 #define ROOTLESS_EUID_ATTR	27287
 #define UIDMAPPATH_ATTR	   27288
 #define GIDMAPPATH_ATTR	   27289
+#define TIMENSOFFSET_ATTR	27292
 #define PREP_ROOTFS_ATTR   27290
 #define MAKE_PARENT_PRIV_ATTR 27291
 #define ROOTFS_PROP_ATTR   27292
@@ -427,6 +432,8 @@ static int nsflag(char *name)
 		return CLONE_NEWUSER;
 	else if (!strcmp(name, "uts"))
 		return CLONE_NEWUTS;
+	else if (!strcmp(name, "time"))
+		return CLONE_NEWTIME;
 
 	/* If we don't recognise a name, fallback to 0. */
 	return 0;
@@ -517,6 +524,10 @@ static void nl_parse(int fd, struct nlconfig_t *config)
 		/* sysbox-runc */
 	   case PREP_ROOTFS_ATTR:
 			config->prep_rootfs = readint8(current);
+			break;
+	   case TIMENSOFFSET_ATTR:
+			config->timensoffset = current;
+			config->timensoffset_len = payload_len;
 			break;
 	   case MAKE_PARENT_PRIV_ATTR:
 			config->make_parent_priv = readint8(current);
@@ -645,6 +656,17 @@ int mount_shiftfs(struct nlconfig_t *config) {
 
 /* Defined in cloned_binary.c. */
 extern int ensure_cloned_binary(void);
+
+static void update_timens(char *map, size_t map_len)
+{
+	if (map == NULL || map_len == 0)
+		return;
+	write_log(DEBUG, "update /proc/self/timens_offsets to '%s'", map);
+	if (write_file(map, map_len, "/proc/self/timens_offsets") < 0) {
+		if (errno != EPERM)
+			bail("failed to update /proc/self/timens_offsets");
+	}
+}
 
 void nsexec(void)
 {
@@ -1072,6 +1094,11 @@ void nsexec(void)
 			 */
 			if (unshare(config.cloneflags & ~CLONE_NEWCGROUP) < 0)
 			  bail("failed to unshare namespaces");
+
+			/*
+			 * set boottime and monotonic timens offsets.
+			 */
+			update_timens(config.timensoffset, config.timensoffset_len);
 
 			/*
 			 * TODO: What about non-namespace clone flags that we're dropping here?

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -55,6 +55,7 @@ func initMaps() {
 			specs.IPCNamespace:     configs.NEWIPC,
 			specs.UTSNamespace:     configs.NEWUTS,
 			specs.CgroupNamespace:  configs.NEWCGROUP,
+			specs.TimeNamespace:    configs.NEWTIME,
 		}
 
 		mountPropagationMapping = map[string]int{
@@ -453,6 +454,9 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 				config.IntelRdt.MemBwSchema = spec.Linux.IntelRdt.MemBwSchema
 			}
 		}
+
+		// update timens offsets
+		config.TimeOffsets = spec.Linux.TimeOffsets
 	}
 	if spec.Process != nil {
 		config.OomScoreAdj = spec.Process.OOMScoreAdj


### PR DESCRIPTION
- porting https://github.com/opencontainers/runc/pull/3876

"time" namespace was introduced in Linux v5.6
support new time namespace to set boottime and monotonic time offset

Example runtime spec

"timeOffsets": {
    "monotonic": {
        "secs": 172800,
        "nanosecs": 0
    },
    "boottime": {
        "secs": 604800,
        "nanosecs": 0
    }
}


(cherry picked from commit ebc2e7c43523d067a56b561dc92e7b59d6392b87)