### PR TITLE
feat: add time namespace support (CLONE_NEWTIME)

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -227,6 +227,10 @@ type Config struct {
 	// ShiftfsMounts is a list of directories on which shiftfs needs to be mounted
 	ShiftfsMounts []shiftfs.MountPoint `json:"shiftfs_mounts,omitempty"`
 
+	// TimeOffsets specifies the boot and monotonic clock offsets for a time
+	// namespace. Requires Linux 5.6+ and NEWTIME in Namespaces.
+	TimeOffsets map[string]specs.LinuxTimeOffset `json:"time_offsets,omitempty"`
+
 	// SwitchDockerDns indicates if the containers should change the IP address
 	// of Docker DNS hosts with localhost addresses.
 	SwitchDockerDns bool `json:"switch_docker_dns,omitempty"`

--- a/libcontainer/configs/namespaces_syscall.go
+++ b/libcontainer/configs/namespaces_syscall.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package configs
@@ -16,6 +17,7 @@ var namespaceInfo = map[NamespaceType]int{
 	NEWUTS:    unix.CLONE_NEWUTS,
 	NEWPID:    unix.CLONE_NEWPID,
 	NEWCGROUP: unix.CLONE_NEWCGROUP,
+	NEWTIME:   unix.CLONE_NEWTIME,
 }
 
 // CloneFlags parses the container's Namespaces options to set the correct

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -44,6 +44,9 @@ func (v *ConfigValidator) Validate(config *configs.Config) error {
 	if err := v.cgroupnamespace(config); err != nil {
 		return err
 	}
+	if err := v.timenamespace(config); err != nil {
+		return err
+	}
 	if err := v.sysctl(config); err != nil {
 		return err
 	}
@@ -126,6 +129,17 @@ func (v *ConfigValidator) cgroupnamespace(config *configs.Config) error {
 	if config.Namespaces.Contains(configs.NEWCGROUP) {
 		if _, err := os.Stat("/proc/self/ns/cgroup"); os.IsNotExist(err) {
 			return errors.New("cgroup namespaces aren't enabled in the kernel")
+		}
+	}
+	return nil
+}
+
+// timenamespace validates that the kernel supports time namespaces when one
+// is requested.
+func (v *ConfigValidator) timenamespace(config *configs.Config) error {
+	if config.Namespaces.Contains(configs.NEWTIME) {
+		if _, err := os.Stat("/proc/self/timens_offsets"); os.IsNotExist(err) {
+			return errors.New("time namespaces aren't enabled in the kernel")
 		}
 	}
 	return nil

--- a/libcontainer/configs/validate/validator.go
+++ b/libcontainer/configs/validate/validator.go
@@ -141,6 +141,10 @@ func (v *ConfigValidator) timenamespace(config *configs.Config) error {
 		if _, err := os.Stat("/proc/self/timens_offsets"); os.IsNotExist(err) {
 			return errors.New("time namespaces aren't enabled in the kernel")
 		}
+	} else {
+		if config.TimeOffsets != nil {
+			return errors.New("time namespace offsets specified, but time namespace isn't enabled in the config")
+		}
 	}
 	return nil
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2374,7 +2374,7 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 	}
 
 	// Write boottime and monotonic time namespace offsets.
-	if c.config.Namespaces.Contains(configs.NEWTIME) && c.config.TimeOffsets != nil {
+	if c.config.TimeOffsets != nil {
 		var offsetSpec bytes.Buffer
 		for clock, offset := range c.config.TimeOffsets {
 			fmt.Fprintf(&offsetSpec, "%s %d %d\n", clock, offset.Secs, offset.Nanosecs)

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2373,6 +2373,18 @@ func (c *linuxContainer) bootstrapData(cloneFlags uintptr, nsMaps map[configs.Na
 
 	}
 
+	// Write boottime and monotonic time namespace offsets.
+	if c.config.Namespaces.Contains(configs.NEWTIME) && c.config.TimeOffsets != nil {
+		var offsetSpec bytes.Buffer
+		for clock, offset := range c.config.TimeOffsets {
+			fmt.Fprintf(&offsetSpec, "%s %d %d\n", clock, offset.Secs, offset.Nanosecs)
+		}
+		r.AddData(&Bytemsg{
+			Type:  TimeOffsetsAttr,
+			Value: offsetSpec.Bytes(),
+		})
+	}
+
 	return bytes.NewReader(r.Serialize()), nil
 }
 

--- a/libcontainer/message_linux.go
+++ b/libcontainer/message_linux.go
@@ -29,6 +29,7 @@ const (
 	RootfsAttr         uint16 = 27293
 	ParentMountAttr    uint16 = 27294
 	ShiftfsMountsAttr  uint16 = 27295
+	TimeOffsetsAttr    uint16 = 27296
 )
 
 type Int32msg struct {

--- a/libcontainer/nsenter/namespace.h
+++ b/libcontainer/nsenter/namespace.h
@@ -28,5 +28,8 @@
 #ifndef CLONE_NEWNET
 #	define CLONE_NEWNET 0x40000000 /* New network namespace */
 #endif
+#ifndef CLONE_NEWTIME
+#	define CLONE_NEWTIME 0x00000080 /* New time namespace */
+#endif
 
 #endif /* NSENTER_NAMESPACE_H */

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -99,6 +99,10 @@ struct nlconfig_t {
 	size_t parent_mount_len;
 	char *shiftfs_mounts;
 	size_t shiftfs_mounts_len;
+
+	/* Time namespace offsets. */
+	char *timensoffset;
+	size_t timensoffset_len;
 };
 
 #define PANIC   "panic"
@@ -130,6 +134,7 @@ static int logfd = -1;
 #define ROOTFS_ATTR        27293
 #define PARENT_MOUNT_ATTR  27294
 #define SHIFTFS_MOUNTS_ATTR 27295
+#define TIMENSOFFSET_ATTR   27296
 
 /*
  * Use the raw syscall for versions of glibc which don't include a function for
@@ -353,6 +358,40 @@ static void update_oom_score_adj(char *data, size_t len)
 		bail("failed to update /proc/self/oom_score_adj");
 }
 
+/*
+ * Write time namespace clock offsets to /proc/self/timens_offsets.
+ * Must be called after unshare(CLONE_NEWTIME) and before any thread is
+ * created in the new namespace.
+ *
+ * When the calling task is in a new user namespace whose uid_map does
+ * not include kernel-global uid 0, the kernel makes /proc/self files
+ * appear owned by global root unless the task is user-dumpable. Without
+ * PR_SET_DUMPABLE=1 the open(O_RDWR) below fails with EACCES, since
+ * fsuid (kernel-global 0) and the file's mapped uid (overflow uid in
+ * our user-ns) don't match for the owner-permission check. Set the
+ * dumpable bit across the write and restore the previous value.
+ */
+static void update_timens(char *map, size_t map_len)
+{
+	if (map == NULL || map_len == 0)
+		return;
+
+	int prev_dump = prctl(PR_GET_DUMPABLE);
+	if (prev_dump != 1)
+		(void)prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
+
+	int ret = write_file(map, map_len, "/proc/self/timens_offsets");
+	int werr = errno;
+
+	if (prev_dump != 1)
+		(void)prctl(PR_SET_DUMPABLE, prev_dump, 0, 0, 0);
+
+	if (ret < 0) {
+		errno = werr;
+		bail("failed to update /proc/self/timens_offsets");
+	}
+}
+
 /* A dummy function that just jumps to the given jumpval. */
 static int child_func(void *arg) __attribute__ ((noinline));
 static int child_func(void *arg)
@@ -427,6 +466,8 @@ static int nsflag(char *name)
 		return CLONE_NEWUSER;
 	else if (!strcmp(name, "uts"))
 		return CLONE_NEWUTS;
+	else if (!strcmp(name, "time"))
+		return CLONE_NEWTIME;
 
 	/* If we don't recognise a name, fallback to 0. */
 	return 0;
@@ -535,6 +576,10 @@ static void nl_parse(int fd, struct nlconfig_t *config)
 		case SHIFTFS_MOUNTS_ATTR:
 			config->shiftfs_mounts = current;
 			config->shiftfs_mounts_len = payload_len;
+			break;
+		case TIMENSOFFSET_ATTR:
+			config->timensoffset = current;
+			config->timensoffset_len = payload_len;
 			break;
 		default:
 			bail("unknown netlink message type %d", nlattr->nla_type);
@@ -1070,8 +1115,20 @@ void nsexec(void)
 			 * some old kernel versions where clone(CLONE_PARENT | CLONE_NEWPID)
 			 * was broken, so we'll just do it the long way anyway.
 			 */
+			int unshared_timens = config.cloneflags & CLONE_NEWTIME;
 			if (unshare(config.cloneflags & ~CLONE_NEWCGROUP) < 0)
 			  bail("failed to unshare namespaces");
+
+			/*
+			 * Set time namespace clock offsets only if we just unshared
+			 * CLONE_NEWTIME (i.e. created a new time namespace). For exec
+			 * paths the time ns is joined via setns, not unshared, so the
+			 * offsets are already set and writing them again would fail.
+			 * Must happen before clone_parent() forks JUMP_INIT so that no
+			 * thread exists yet in the new timens.
+			 */
+			if (unshared_timens)
+				update_timens(config.timensoffset, config.timensoffset_len);
 
 			/*
 			 * TODO: What about non-namespace clone flags that we're dropping here?

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -371,7 +371,7 @@ static void update_oom_score_adj(char *data, size_t len)
  * our user-ns) don't match for the owner-permission check. Set the
  * dumpable bit across the write and restore the previous value.
  */
-static void update_timens(char *map, size_t map_len)
+static void update_timens_offsets(char *map, size_t map_len)
 {
 	if (map == NULL || map_len == 0)
 		return;
@@ -1128,7 +1128,7 @@ void nsexec(void)
 			 * thread exists yet in the new timens.
 			 */
 			if (unshared_timens)
-				update_timens(config.timensoffset, config.timensoffset_len);
+				update_timens_offsets(config.timensoffset, config.timensoffset_len);
 
 			/*
 			 * TODO: What about non-namespace clone flags that we're dropping here?

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -438,6 +438,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 		config.ReadonlyPaths = spec.Linux.ReadonlyPaths
 		config.MountLabel = spec.Linux.MountLabel
 		config.Sysctl = spec.Linux.Sysctl
+		config.TimeOffsets = spec.Linux.TimeOffsets
 		if spec.Linux.Seccomp != nil {
 			seccomp, err := SetupSeccomp(spec.Linux.Seccomp)
 			if err != nil {
@@ -454,9 +455,6 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 				config.IntelRdt.MemBwSchema = spec.Linux.IntelRdt.MemBwSchema
 			}
 		}
-
-		// Propagate time namespace clock offsets.
-		config.TimeOffsets = spec.Linux.TimeOffsets
 	}
 	if spec.Process != nil {
 		config.OomScoreAdj = spec.Process.OOMScoreAdj

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -55,6 +55,7 @@ func initMaps() {
 			specs.IPCNamespace:     configs.NEWIPC,
 			specs.UTSNamespace:     configs.NEWUTS,
 			specs.CgroupNamespace:  configs.NEWCGROUP,
+			specs.TimeNamespace:    configs.NEWTIME,
 		}
 
 		mountPropagationMapping = map[string]int{
@@ -453,6 +454,9 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
 				config.IntelRdt.MemBwSchema = spec.Linux.IntelRdt.MemBwSchema
 			}
 		}
+
+		// Propagate time namespace clock offsets.
+		config.TimeOffsets = spec.Linux.TimeOffsets
 	}
 	if spec.Process != nil {
 		config.OomScoreAdj = spec.Process.OOMScoreAdj

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -382,6 +382,11 @@ function requires() {
 				skip_me=1
 			fi
 			;;
+		timens)
+			if [ ! -e "/proc/self/ns/time" ]; then
+				skip_me=1
+			fi
+			;;
 		cgroups_v1)
 			init_cgroup_paths
 			if [ "$CGROUP_UNIFIED" != "no" ]; then

--- a/tests/integration/helpers.bash
+++ b/tests/integration/helpers.bash
@@ -526,7 +526,7 @@ function setup_busybox() {
 		BUSYBOX_IMAGE="/testdata/busybox.tar"
 	fi
 	if [ ! -e $BUSYBOX_IMAGE ]; then
-		curl -o $BUSYBOX_IMAGE -sSL $(get_busybox)
+		curl -o $BUSYBOX_IMAGE -fsSL $(get_busybox)
 	fi
 	tar --exclude './dev/*' -C "$BUSYBOX_BUNDLE"/rootfs -xf "$BUSYBOX_IMAGE"
 

--- a/tests/integration/multi-arch.bash
+++ b/tests/integration/multi-arch.bash
@@ -2,10 +2,10 @@
 get_busybox() {
 	case $(go env GOARCH) in
 	arm64)
-		echo 'https://github.com/docker-library/busybox/raw/dist-arm64v8/stable/glibc/busybox.tar.xz'
+		echo 'https://github.com/docker-library/busybox/raw/8141f5b047a1fbeefd842388244c045825a61c90/latest/glibc/arm64v8/rootfs.tar.gz'
 		;;
 	*)
-		echo 'https://github.com/docker-library/busybox/raw/dist-amd64/stable/glibc/busybox.tar.xz'
+		echo 'https://github.com/docker-library/busybox/raw/9c2d0c6fbaaf2ca1b4c19027fa515d9e797e7199/latest/glibc/amd64/rootfs.tar.gz'
 		;;
 	esac
 }

--- a/tests/integration/timens.bats
+++ b/tests/integration/timens.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+# Tests for time namespace support (CLONE_NEWTIME, Linux 5.6+).
+# Ported from opencontainers/runc tests/integration/timens.bats.
+
+load helpers
+
+function setup() {
+	setup_busybox
+}
+
+function teardown() {
+	teardown_busybox
+}
+
+# Specifying time offsets without a time namespace must fail.
+@test "runc run [timens offsets with no timens]" {
+	requires timens
+
+	update_config '.process.args = ["cat", "/proc/self/timens_offsets"]'
+	update_config '.linux.namespaces = (.linux.namespaces | map(select(.type != "time")))'
+	update_config '.linux.timeOffsets = {
+			"monotonic": { "secs": 7881, "nanosecs": 2718281 },
+			"boottime":  { "secs": 1337, "nanosecs": 3141519 }
+		}'
+
+	runc run --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -ne 0 ]
+}
+
+# A time namespace with no offsets should show zeros in timens_offsets.
+@test "runc run [timens with no offsets]" {
+	requires timens
+
+	update_config '.process.args = ["sleep", "inf"]'
+	update_config '.linux.namespaces += [{"type": "time"}]
+		| .linux.timeOffsets = null'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	runc exec test_busybox cat /proc/self/timens_offsets
+	[ "$status" -eq 0 ]
+	grep -E '^monotonic\s+0\s+0$' <<<"$output"
+	grep -E '^boottime\s+0\s+0$' <<<"$output"
+}
+
+# Basic time namespace with explicit offsets.
+@test "runc run [simple timens]" {
+	requires timens
+
+	update_config '.process.args = ["sleep", "inf"]'
+	update_config '.linux.namespaces += [{"type": "time"}]
+		| .linux.timeOffsets = {
+			"monotonic": { "secs": 7881, "nanosecs": 2718281 },
+			"boottime":  { "secs": 1337, "nanosecs": 3141519 }
+		}'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	runc exec test_busybox cat /proc/self/timens_offsets
+	[ "$status" -eq 0 ]
+	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
+	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
+}
+
+# exec into a running container must see the same timens offsets.
+@test "runc exec [simple timens]" {
+	requires timens
+
+	update_config '.process.args = ["sleep", "inf"]'
+	update_config '.linux.namespaces += [{"type": "time"}]
+		| .linux.timeOffsets = {
+			"monotonic": { "secs": 7881, "nanosecs": 2718281 },
+			"boottime":  { "secs": 1337, "nanosecs": 3141519 }
+		}'
+
+	runc run -d --console-socket "$CONSOLE_SOCKET" test_busybox
+	[ "$status" -eq 0 ]
+
+	runc exec test_busybox cat /proc/self/timens_offsets
+	[ "$status" -eq 0 ]
+	grep -E '^monotonic\s+7881\s+2718281$' <<<"$output"
+	grep -E '^boottime\s+1337\s+3141519$' <<<"$output"
+}


### PR DESCRIPTION
Add support for [time namespaces](https://man7.org/linux/man-pages/man7/time_namespaces.7.html) in sysbox-runc. Also, add a corresponding test in `tests/integration/timens.bats`.

Note: several parts borrowed from OCI runc commit [ebc2e7c](https://github.com/opencontainers/runc/commit/ebc2e7c43523d067a56b561dc92e7b59d6392b87).