### PR TITLE
syscont: add time namespace to sys container by default

### DIFF
--- a/libsysbox/syscont/spec.go
+++ b/libsysbox/syscont/spec.go
@@ -287,7 +287,14 @@ func cfgNamespaces(sysMgr *sysbox.Mgr, spec *specs.Spec) error {
 
 	// user-ns and cgroup-ns are not required per the OCI spec, but we will add
 	// them to the system container spec.
-	var allNs = []string{"pid", "ipc", "uts", "mount", "network", "user", "cgroup"}
+	//
+	// time-ns is also added by default (with no offsets relative to the host)
+	// so that the container gets its own time namespace owned by the
+	// container's user-ns. Without this, tools inside the container that
+	// setns() into the host time-ns (e.g. `nsenter -a` from newer util-linux)
+	// fail with EPERM, since the host time-ns is owned by init_user_ns. If
+	// the OCI spec already specifies a time namespace, it is honored as-is.
+	var allNs = []string{"pid", "ipc", "uts", "mount", "network", "user", "cgroup", "time"}
 	var reqNs = []string{"pid", "ipc", "uts", "mount", "network"}
 
 	allNsSet := mapset.NewSet[string]()


### PR DESCRIPTION
Auto-add a time namespace to the sys container's spec (with no offsets relative to the host) when not explicitly specified by the OCI spec.

This makes the container's time namespace owned by the container's user-ns rather than init_user_ns. Without this, tools inside the container that setns() into the host time-ns (e.g. `nsenter -a` from newer util-linux) fail with EPERM, since CAP_SYS_ADMIN is required in both the target time-ns's user-ns and the caller's user-ns, and the container's root has CAP_SYS_ADMIN only in its own user-ns.

If the OCI spec already specifies a time namespace, it is honored.