### PR TITLE
port rlimit NOFILE Go runtime cache clearing from runc

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -87,6 +87,9 @@ func newContainerInit(t initType, pipe *os.File, consoleSocket, fifoFile *os.Fil
 		if err := json.NewDecoder(pipe).Decode(&config); err != nil {
 			return nil, err
 		}
+		// Clean the RLIMIT_NOFILE cache in go runtime.
+		// Issue: https://github.com/opencontainers/runc/issues/4195
+		maybeClearRlimitNofileCache(config.Rlimits)
 		if err := populateProcessEnvironment(config.Env); err != nil {
 			return nil, err
 		}
@@ -536,6 +539,18 @@ func setupRoute(config *configs.Config) error {
 		}
 	}
 	return nil
+}
+
+func maybeClearRlimitNofileCache(limits []configs.Rlimit) {
+	for _, rlimit := range limits {
+		if rlimit.Type == syscall.RLIMIT_NOFILE {
+			system.ClearRlimitNofileCache(&syscall.Rlimit{
+				Cur: rlimit.Soft,
+				Max: rlimit.Hard,
+			})
+			return
+		}
+	}
 }
 
 func setupRlimits(limits []configs.Rlimit, pid int) error {

--- a/libcontainer/system/rlimit_linux.go
+++ b/libcontainer/system/rlimit_linux.go
@@ -1,0 +1,13 @@
+package system
+
+import (
+	"syscall"
+)
+
+// ClearRlimitNofileCache clears go runtime's nofile rlimit cache. The argument
+// is process RLIMIT_NOFILE values. Relies on go.dev/cl/588076.
+func ClearRlimitNofileCache(lim *syscall.Rlimit) {
+	// Ignore the return values since we only need to clean the cache,
+	// the limit is going to be set via unix.Prlimit elsewhere.
+	_ = syscall.Setrlimit(syscall.RLIMIT_NOFILE, lim)
+}


### PR DESCRIPTION
This is the fix for https://github.com/opencontainers/runc/issues/4195.

https://github.com/nestybox/sysbox/issues/1014
Signed-off-by: Benjamin Peterson <benjamin@engflow.com>
