### PR TITLE
fix: handle initMount helper completion

### DIFF
--- a/init.go
+++ b/init.go
@@ -39,12 +39,18 @@ var initCommand = cli.Command{
 	Name:  "init",
 	Usage: `initialize the namespaces and launch the process (do not call it outside of sysbox-runc)`,
 	Action: func(context *cli.Context) error {
+		initType := os.Getenv("_LIBCONTAINER_INITTYPE")
+
 		factory, _ := libcontainer.New("")
 		if err := factory.StartInitialization(); err != nil {
-			// as the error is sent back to the parent there is no need to log
-			// or write it to stderr because the parent process will handle this
 			os.Exit(1)
 		}
+
+		// initMount helpers return here without exec; that's normal.
+		if initType == "mount" {
+			os.Exit(0)
+		}
+
 		panic("libcontainer: container init failed to exec")
 	},
 }

--- a/libcontainer/factory_linux.go
+++ b/libcontainer/factory_linux.go
@@ -402,6 +402,12 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 	defer func() {
 		// We have an error during the initialization of the container's init,
 		// send it back to the parent process in the form of an initError.
+		// For initMount helpers, Init() returns nil without exec'ing;
+		// sending procError with a nil payload would cause the parent's
+		// parseSync to panic ("No error following JSON procError payload").
+		if err == nil {
+			return
+		}
 		if werr := utils.WriteJSON(pipe, syncT{procError}); werr != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return


### PR DESCRIPTION
initMount helpers return from StartInitialization without exec'ing after completing their work. Avoid sending a nil procError payload on successful helper completion and exit cleanly from the init command instead of panicking.

This was a finding while investigating: https://github.com/nestybox/sysbox/issues/1013