### PR TITLE
fix: support sysbox on containerd 2 nodes for ubuntu 24.04 + kernel 6.8

### DIFF
--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -2444,7 +2444,7 @@ func (c *linuxContainer) handleReqOp(childPid int, reqs []opReq) error {
 	op := reqs[0].Op
 
 	switch op {
-	case bind, chown, mkdir, overlay, rootfsIDMap, switchDockerDns:
+	case bind, chown, mkdir, overlay, rootfsIDMap, switchDockerDns, sysfs:
 		return c.handleOp(op, childPid, reqs)
 	default:
 		return newSystemError(fmt.Errorf("invalid opReq type %d", int(op)))
@@ -2490,7 +2490,7 @@ func (c *linuxContainer) handleOp(op opReqType, childPid int, reqs []opReq) erro
 	namespaces := []string{}
 
 	switch op {
-	case bind, chown, mkdir, overlay, rootfsIDMap:
+	case bind, chown, mkdir, overlay, rootfsIDMap, sysfs:
 		namespaces = append(namespaces,
 			fmt.Sprintf("mnt:/proc/%d/ns/mnt", childPid),
 			fmt.Sprintf("pid:/proc/%d/ns/pid", childPid),

--- a/libcontainer/nsenter/nsexec.c
+++ b/libcontainer/nsenter/nsexec.c
@@ -642,11 +642,21 @@ void join_namespaces(char *nslist)
 	} while ((namespace = strtok_r(NULL, ",", &saveptr)) != NULL);
 
 	/*
-	 * The ordering in which we join namespaces is important. We should
-	 * always join the user namespace *first*. This is all guaranteed
-	 * from the container_linux.go side of this, so we're just going to
-	 * follow the order given to us.
+	 * Ordering matters here. Per setns(2), joining the netns requires
+	 * CAP_SYS_ADMIN in the user namespace that owns it, which is the
+	 * host's, not the container's. Once we setns(2)/unshare(2) into the
+	 * container's user namespace, that host capability is gone for good
+	 * (user_namespaces(7)), so the netns join would then fail. Hence we
+	 * join the netns first and the user namespace last.
 	 */
+	for (i = 0; i < num; i++) {
+		if (namespaces[i].ns == CLONE_NEWNET && i > 0) {
+			struct namespace_t netns = namespaces[i];
+			memmove(&namespaces[1], &namespaces[0], i * sizeof(struct namespace_t));
+			namespaces[0] = netns;
+			break;
+		}
+	}
 
 	for (i = 0; i < num; i++) {
 		struct namespace_t ns = namespaces[i];

--- a/libcontainer/rootfs_init_linux.go
+++ b/libcontainer/rootfs_init_linux.go
@@ -545,6 +545,31 @@ func (l *linuxRootfsInit) Init() error {
 			}
 		}
 
+	case sysfs:
+		rootfs := l.reqs[0].Rootfs
+		m := &l.reqs[0].Mount
+
+		if err := unix.Chdir(rootfs); err != nil {
+			return newSystemErrorWithCausef(err, "chdir to rootfs %s", rootfs)
+		}
+
+		if err := libcontainerUtils.WithProcfd(".", m.Destination, func(procfd string) error {
+			return unix.Mount(m.Source, procfd, m.Device, uintptr(m.Flags), m.Data)
+		}); err != nil {
+			return newSystemErrorWithCausef(err, "sysfs mount through procfd to %s", m.Destination)
+		}
+
+		if err := libcontainerUtils.WithProcfd(".", m.Destination, func(procfd string) error {
+			for _, pflag := range m.PropagationFlags {
+				if err := unix.Mount("", procfd, "", uintptr(pflag), ""); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			return newSystemErrorWithCausef(err, "change sysfs mount propagation through procfd to %s", m.Destination)
+		}
+
 	case switchDockerDns:
 		oldDns := l.reqs[0].OldDns
 		newDns := l.reqs[0].NewDns

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -454,6 +454,17 @@ func mountToRootfs(m *configs.Mount, config *configs.Config, enableCgroupns bool
 		if err := mkdirall(dest, 0755, config, pipe); err != nil {
 			return fmt.Errorf("failed to created dir for %s mount: %v", m.Device, err)
 		}
+		if m.Device == "sysfs" {
+			req := opReq{
+				Op:     sysfs,
+				Rootfs: config.Rootfs,
+				Mount:  *m,
+			}
+			if err := syncParentDoOp([]opReq{req}, pipe); err != nil {
+				return newSystemErrorWithCause(err, "syncing with parent runc to perform sysfs mount")
+			}
+			return nil
+		}
 		// Selinux kernels do not support labeling of /proc or /sys
 		return mountPropagate(m, ".", "")
 	case "mqueue":

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -38,6 +38,7 @@ const (
 	mkdir
 	rootfsIDMap
 	overlay
+	sysfs
 )
 
 type opReq struct {


### PR DESCRIPTION
Fixes nestybox/sysbox#1013.

Supersedes #116. Same underlying fix, originally contributed by @rpahli, but this corrects a few issues found during review. Details in the commit message.

- Sysfs mounts now go through a privileged initMount helper process (mounting via procfd) instead of the container's own init process, fixing "mount through procfd: operation not permitted" failures seen on Ubuntu 24.04 + kernel 6.8 under containerd 2.x.
- Reorders namespace joins in nsexec: the network namespace must be joined before the user namespace, since joining netns requires CAP_SYS_ADMIN in the namespace that owns it (the host's), which is lost once the container's user namespace has been joined.