### PR TITLE
fix: detect bind mount dependencies through symlinks in doBindMounts

### DIFF
--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -581,11 +581,28 @@ func doBindMounts(config *configs.Config, pipe io.ReadWriter, doSysboxfsOvermoun
 		}
 
 		// Determine if the current mount is nested under a still-pending prior
-		// mount's destination. Resolve symlinks first (e.g. image symlink
-		// "/var/run" -> "/run"), since a literal comparison would miss the
-		// dependency and later fail with ENOENT. mntReqs destinations are
-		// already resolved by prepareBindDest(), so resolving here the same
-		// way keeps the comparison apples-to-apples.
+		// mount's destination. The true condition is "would the destination
+		// resolve into the pending mount once that mount is performed", which
+		// can't be computed before actually performing it, so we approximate
+		// it from both sides and flush if either check matches (a false
+		// positive just costs one extra request to the parent):
+		//
+		// - The resolved check catches symlinks *outside* the pending
+		//   mountpoint, which survive the flush. E.g., image symlink
+		//   "/var/run" -> "/run" with a pending mount at "/run": a mount at
+		//   "/var/run/foo" must flush, but a literal comparison misses the
+		//   dependency and the mount later fails with ENOENT. mntReqs
+		//   destinations are already resolved by prepareBindDest(), so
+		//   resolving here the same way keeps the comparison apples-to-apples.
+		//
+		// - The literal check catches paths that enter the pending mountpoint
+		//   through image symlinks *underneath* it, which the flush shadows.
+		//   E.g., image symlink "/run/shm" -> "/dev/shm" with a pending mount
+		//   at "/run": a mount at "/run/shm/foo" must flush so that it lands
+		//   at run/shm/foo on top of the pending mount (matching inline,
+		//   in-order mounting), but pre-flush resolution follows the image
+		//   symlink to "dev/shm/foo" and would silently place the mount at
+		//   the wrong location.
 
 		resolvedDest, err := securejoin.SecureJoin(".", m.Destination)
 		if err != nil {
@@ -595,7 +612,8 @@ func doBindMounts(config *configs.Config, pipe io.ReadWriter, doSysboxfsOvermoun
 		mntDependsOnPrior := false
 		for _, mr := range mntReqs {
 			priorDest := filepath.Join("/", mr.Mount.Destination)
-			if mntDestDependsOn(filepath.Join("/", resolvedDest), priorDest) {
+			if mntDestDependsOn(filepath.Join("/", m.Destination), priorDest) ||
+				mntDestDependsOn(filepath.Join("/", resolvedDest), priorDest) {
 				mntDependsOnPrior = true
 				break
 			}

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -538,6 +538,16 @@ func mountToRootfs(m *configs.Mount, config *configs.Config, enableCgroupns bool
 	}
 }
 
+// mntDestDependsOn returns true if mount destination dest is equal to, or
+// nested inside, mount destination prior. Both paths must be absolute and
+// clean (e.g., as returned by filepath.Join("/", path)).
+func mntDestDependsOn(dest, prior string) bool {
+	if prior == "/" {
+		return true
+	}
+	return dest == prior || strings.HasPrefix(dest, prior+"/")
+}
+
 func doBindMounts(config *configs.Config, pipe io.ReadWriter, doSysboxfsOvermountsOnly bool) error {
 
 	// sysbox-runc: the sys container's init process is in a dedicated
@@ -570,15 +580,41 @@ func doBindMounts(config *configs.Config, pipe io.ReadWriter, doSysboxfsOvermoun
 			continue
 		}
 
-		// Determine if the current mount is dependent on a prior one.
+		// Determine if the current mount is dependent on a prior one (i.e., its
+		// destination path is equal to, or nested inside, the destination of a
+		// prior mount that is still pending in mntReqs).
+		//
+		// The comparison must be done with the mount destination resolved of
+		// symlinks within the container's rootfs, since the image may contain
+		// symlinks along the destination path. E.g., if the image has symlink
+		// "/var/run" -> "/run", a mount with destination "/var/run/foo" lands
+		// inside a prior mount with destination "/run", even though a literal
+		// string comparison won't detect this. Missing the dependency means
+		// prepareBindDest() would create the destination dir underneath the
+		// path that the prior mount will cover once it's performed, so the
+		// current mount would then fail with ENOENT (this is how K8s mounts
+		// the service-account token at /var/run/secrets/... on images where
+		// /var/run is a symlink and a K8s volume is mounted at /run).
+		//
+		// Mount destinations in mntReqs are already resolved and relative to
+		// the rootfs (see prepareBindDest()); thus we prepend "/" for a proper
+		// comparison. The current mount's destination is resolved here against
+		// the rootfs (i.e., the process' cwd). We check both the unresolved
+		// and resolved destinations to be on the safe side (a spurious flush
+		// of the pending mount requests is harmless).
+
+		resolvedDest, err := securejoin.SecureJoin(".", m.Destination)
+		if err != nil {
+			return err
+		}
+
 		mntDependsOnPrior := false
 		for _, mr := range mntReqs {
-
-			// Mount destinations in mntReqs are relative to the rootfs
-			// (see prepareBindDest()); thus we need to prepend "/" for a
-			// proper comparison.
-			if strings.HasPrefix(m.Destination, filepath.Join("/", mr.Mount.Destination)) {
+			priorDest := filepath.Join("/", mr.Mount.Destination)
+			if mntDestDependsOn(filepath.Join("/", m.Destination), priorDest) ||
+				mntDestDependsOn(filepath.Join("/", resolvedDest), priorDest) {
 				mntDependsOnPrior = true
+				break
 			}
 		}
 

--- a/libcontainer/rootfs_linux.go
+++ b/libcontainer/rootfs_linux.go
@@ -580,28 +580,12 @@ func doBindMounts(config *configs.Config, pipe io.ReadWriter, doSysboxfsOvermoun
 			continue
 		}
 
-		// Determine if the current mount is dependent on a prior one (i.e., its
-		// destination path is equal to, or nested inside, the destination of a
-		// prior mount that is still pending in mntReqs).
-		//
-		// The comparison must be done with the mount destination resolved of
-		// symlinks within the container's rootfs, since the image may contain
-		// symlinks along the destination path. E.g., if the image has symlink
-		// "/var/run" -> "/run", a mount with destination "/var/run/foo" lands
-		// inside a prior mount with destination "/run", even though a literal
-		// string comparison won't detect this. Missing the dependency means
-		// prepareBindDest() would create the destination dir underneath the
-		// path that the prior mount will cover once it's performed, so the
-		// current mount would then fail with ENOENT (this is how K8s mounts
-		// the service-account token at /var/run/secrets/... on images where
-		// /var/run is a symlink and a K8s volume is mounted at /run).
-		//
-		// Mount destinations in mntReqs are already resolved and relative to
-		// the rootfs (see prepareBindDest()); thus we prepend "/" for a proper
-		// comparison. The current mount's destination is resolved here against
-		// the rootfs (i.e., the process' cwd). We check both the unresolved
-		// and resolved destinations to be on the safe side (a spurious flush
-		// of the pending mount requests is harmless).
+		// Determine if the current mount is nested under a still-pending prior
+		// mount's destination. Resolve symlinks first (e.g. image symlink
+		// "/var/run" -> "/run"), since a literal comparison would miss the
+		// dependency and later fail with ENOENT. mntReqs destinations are
+		// already resolved by prepareBindDest(), so resolving here the same
+		// way keeps the comparison apples-to-apples.
 
 		resolvedDest, err := securejoin.SecureJoin(".", m.Destination)
 		if err != nil {
@@ -611,8 +595,7 @@ func doBindMounts(config *configs.Config, pipe io.ReadWriter, doSysboxfsOvermoun
 		mntDependsOnPrior := false
 		for _, mr := range mntReqs {
 			priorDest := filepath.Join("/", mr.Mount.Destination)
-			if mntDestDependsOn(filepath.Join("/", m.Destination), priorDest) ||
-				mntDestDependsOn(filepath.Join("/", resolvedDest), priorDest) {
+			if mntDestDependsOn(filepath.Join("/", resolvedDest), priorDest) {
 				mntDependsOnPrior = true
 				break
 			}

--- a/libcontainer/rootfs_linux_test.go
+++ b/libcontainer/rootfs_linux_test.go
@@ -67,3 +67,24 @@ func TestNeedsSetupDevStrangeSourceDest(t *testing.T) {
 		t.Fatal("expected needsSetupDev to be true, got false")
 	}
 }
+
+func TestMntDestDependsOn(t *testing.T) {
+	tests := []struct {
+		dest  string
+		prior string
+		want  bool
+	}{
+		{"/run", "/run", true},
+		{"/run/secrets/kubernetes.io/serviceaccount", "/run", true},
+		{"/run/foo", "/run/foo/bar", false},
+		{"/runfoo", "/run", false},
+		{"/var/run", "/run", false},
+		{"/run", "/", true},
+		{"/", "/", true},
+	}
+	for _, tc := range tests {
+		if got := mntDestDependsOn(tc.dest, tc.prior); got != tc.want {
+			t.Errorf("mntDestDependsOn(%q, %q) = %v, want %v", tc.dest, tc.prior, got, tc.want)
+		}
+	}
+}

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -235,6 +235,50 @@ function teardown() {
 	rm -rf /tmp/busyboxtest
 }
 
+@test "runc run [bind mount dest inside prior mount via symlink under it]" {
+	# Mirror image of the previous test: here the symlink is *inside* the
+	# prior mount's destination (image symlink /run/shm -> /dev/shm, as
+	# shipped by older Ubuntu images). The mount at /run/shm/foo must land
+	# on top of the /run mount (matching inline, in-order mounting), not at
+	# /dev/shm/foo where the image symlink (about to be shadowed by the
+	# /run mount) points before the mounts are performed.
+
+	mkdir -p /tmp/busyboxtest/emptydir
+	mkdir -p /tmp/busyboxtest/vol
+	touch /tmp/busyboxtest/vol/vol-file
+
+	# in container image, /run/shm -> /dev/shm
+	mkdir -p rootfs/run
+	rm -rf rootfs/run/shm
+	ln -s /dev/shm rootfs/run/shm
+
+	if [ -z "$SHIFT_ROOTFS_UIDS" ]; then
+		chown "$UID_MAP":"$GID_MAP" rootfs/run
+		chown -h "$UID_MAP":"$GID_MAP" rootfs/run/shm
+	fi
+
+	update_config ' .mounts |= . + [{
+												 source: "/tmp/busyboxtest/emptydir",
+												 destination: "/run",
+												 options: ["bind", "rw"]
+											 },
+											 {
+												 source: "/tmp/busyboxtest/vol",
+												 destination: "/run/shm/foo",
+												 options: ["bind", "rw"]
+											 }]
+						 | .process.args = ["sh", "-c", "ls /run/shm/foo && ls /dev/shm/"]'
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" =~ 'vol-file' ]]
+
+	# The mount must not have leaked to where the image symlink pointed.
+	[[ "$output" != *'foo'* ]]
+
+	rm -rf /tmp/busyboxtest
+}
+
 @test "runc run [tmpfs mount with absolute symlink]" {
 	# in container, /conf -> /real/conf
 	mkdir -p rootfs/real/conf

--- a/tests/integration/mounts.bats
+++ b/tests/integration/mounts.bats
@@ -191,6 +191,50 @@ function teardown() {
 	rm -rf /tmp/busyboxtest
 }
 
+@test "runc run [bind mount dest nested in prior mount via symlink]" {
+	# Repro for the K8s service-account token mount failure: a bind mount
+	# whose destination resolves (through a symlink in the container image)
+	# to a path nested inside the destination of a prior bind mount in the
+	# mount list, and which does not exist inside the prior mount's source.
+	#
+	# This mimics K8s mounting an emptyDir volume at /run and the projected
+	# service-account token at /var/run/secrets/kubernetes.io/serviceaccount,
+	# on an image where /var/run is a symlink to /run.
+
+	mkdir -p /tmp/busyboxtest/emptydir
+	mkdir -p /tmp/busyboxtest/token
+	touch /tmp/busyboxtest/token/token-file
+
+	# in container, /var/run -> /run
+	mkdir -p rootfs/run
+	mkdir -p rootfs/var
+	rm -rf rootfs/var/run
+	ln -s /run rootfs/var/run
+
+	if [ -z "$SHIFT_ROOTFS_UIDS" ]; then
+		chown "$UID_MAP":"$GID_MAP" rootfs/run rootfs/var
+		chown -h "$UID_MAP":"$GID_MAP" rootfs/var/run
+	fi
+
+	update_config ' .mounts |= . + [{
+												 source: "/tmp/busyboxtest/emptydir",
+												 destination: "/run",
+												 options: ["bind", "rw"]
+											 },
+											 {
+												 source: "/tmp/busyboxtest/token",
+												 destination: "/var/run/secrets/kubernetes.io/serviceaccount",
+												 options: ["bind", "ro"]
+											 }]
+						 | .process.args = ["ls", "/run/secrets/kubernetes.io/serviceaccount"]'
+
+	runc run test_busybox
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" =~ 'token-file' ]]
+
+	rm -rf /tmp/busyboxtest
+}
+
 @test "runc run [tmpfs mount with absolute symlink]" {
 	# in container, /conf -> /real/conf
 	mkdir -p rootfs/real/conf


### PR DESCRIPTION
Fixes nestybox/sysbox#1026 (K8s pods with a volume at `/run` + an image with a
`/var/run -> /run` symlink fail to start; breaks e.g. all CloudNativePG clusters).

`doBindMounts()` batches bind mount requests for bulk execution by the parent's helper
process. A mount whose destination is nested inside a still-pending earlier mount must
flush the batch first, so its destination is resolved and created on top of the mounted
filesystem rather than on the image directory the earlier mount is about to cover. The
dependency check compared the current mount's unresolved destination against the
pending mounts' symlink-resolved destinations with a raw `strings.HasPrefix`, so
dependencies arising through image symlinks (`/var/run -> /run`) were missed. The
nested destination then got created in the image rootfs, was shadowed when the pending
mount was performed, and the dependent mount failed with:

```
bind mount through procfd of <src> -> run/secrets/kubernetes.io/serviceaccount:
open o_path procfd: openat ... no such file or directory
```

Changes:

- `doBindMounts()`: resolve the current mount's destination with
  `securejoin.SecureJoin(".", ...)` (the same resolution `prepareBindDest()` performs)
  before the dependency comparison. Check both the unresolved and resolved
  destinations against every pending mount, so detection is a strict superset of the
  previous behavior — a spurious flush costs one extra request to the parent, a missed
  dependency is fatal.
- New `mntDestDependsOn()` helper comparing at path component boundaries (`/runfoo` is
  no longer considered nested under `/run`).
- Unit test `TestMntDestDependsOn`; integration test
  `"runc run [bind mount dest nested in prior mount via symlink]"` in
  `tests/integration/mounts.bats` reproducing the K8s service-account-token scenario
  (fails without the fix, passes with it).

The dependency check only decides *when to flush*; the final destination still comes
from `prepareBindDest()`'s own resolution after the flush, so the change cannot alter
the semantics of mounts that were already handled correctly. Mount lists without
nested destinations are still sent as a single bulk request.

Verified:

- The failure was reproduced with the stock v0.7.0 CE release binary on a real
  cluster node (OKE, kernel 6.17, containerd 2.2.6), using both the standalone OCI
  bundle from the linked issue and a CloudNativePG pod.
- With this patch on the same node: the standalone repro passes, and a real
  CloudNativePG cluster starts and serves under sysbox with `hostUsers: false`
  (kubelet user namespaces) — the configuration that was failing.
- The added `mounts.bats` integration test encodes the same scenario, so CI covers it
  going forward.
